### PR TITLE
doc(lean/main/dsls.lean): fix double error

### DIFF
--- a/lean/main/dsls.lean
+++ b/lean/main/dsls.lean
@@ -234,7 +234,9 @@ def eg_AExp_fail: AExp :=
   [imp_aexp'| 42 + 43]
 -- elab_aexp_ident failed.
 -- elab_aexp_num failed
-
+.
+-- the `.` above is to prevent the error message from the previous `def` to
+-- read also the comments appearing below it.
 /-
 Clearly, both parses `elab_aexp_ident` and `elab_aexp_num`
 are tried in succession, and both fail, leading to an error.


### PR DESCRIPTION
... and, on the way, mention the existence of `.`.