### PR TITLE
Add a GitHub action to build LaTeX + a PDF on push

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,52 @@
+name: Book
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  book:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: brew install pandoc mactex-no-gui homebrew/homebrew-cask-fonts/font-dejavu pygments
+
+    - name: Download the Book Template
+      run: |
+        curl -L https://github.com/Wandmalfarbe/pandoc-latex-template/releases/download/v2.0.0/Eisvogel.tar.gz | tar -xz eisvogel.latex
+
+    - name: Build Some LaTeX
+      run: |
+        pandoc --to latex md/cover.md $(grep -o '\(md/.*\.md\)' README.md | tr -d '(' | tr -d ')') --toc --template ./eisvogel.latex --top-level-division=chapter -V documentclass=book -V classoption=oneside --no-highlight |
+          sed -e 's/\\begin{verbatim}/\\begin{minted}{Lean}/' -e 's/{verbatim}/{minted}/' -e's/% Listings/\\usepackage{minted}\n\\newmintinline[lean]{pygments\/lean4.py:Lean4Lexer -x}{bgcolor=white}\n\\newminted[leancode]{pygments\/lean4.py:Lean4Lexer -x}{fontsize=\\footnotesize}\n\\setminted{fontsize=\\footnotesize, breaklines}\n/' >out.tex
+
+    - name: Build a PDF
+      # Running twice appears to be necessary to not get a blank TOC?!
+      run: /Library/TeX/texbin/lualatex -shell-escape out.tex && /Library/TeX/texbin/lualatex -shell-escape out.tex
+
+    - name: Rename
+      run: mv out.tex 'Metaprogramming in Lean 4.tex' && mv out.pdf 'Metaprogramming in Lean 4.pdf'
+
+    - name: Delete old release assets
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ github.token }}
+        tag: latest
+        fail-if-no-assets: false
+        fail-if-no-release: false
+        assets: |
+          *.tex
+          *.pdf
+
+    - name: Upload Outputs
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: latest
+        generate_release_notes: true
+        files: |
+          Metaprogramming in Lean 4.tex
+          Metaprogramming in Lean 4.pdf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Authors: Arthur Paulino, Damiano Testa, Edward Ayers, Henrik Böving, Jannis Lim
 Sources to extract material from:
 * [Material written by Ed](https://github.com/leanprover-community/mathlib4/blob/tutorial/docs/metaprogramming/02_metavariables.md)
 
+A PDF is also [available here for download](../../releases/download/latest/Metaprogramming.in.Lean.4.pdf) (and is rebuilt on each change).
+
 ## Collaborating
 
 The markdown files are generated automatically via

--- a/lean/cover.lean
+++ b/lean/cover.lean
@@ -1,13 +1,19 @@
 /-
-# Lean 4 Metaprogramming Book
+---
+title: "Metaprogramming in Lean 4"
+author: [Arthur Paulino, Damiano Testa, Edward Ayers, Henrik Böving,
+         Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
+# abusing this field just because the template puts it at a decent right-sized spot
+date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https://github.com/Wandmalfarbe/pandoc-latex-template)"
+mainfont: "DejaVu Serif"
+monofont: "DejaVu Sans Mono"
+book: true
+titlepage: true
+titlepage-color: "083045"
+titlepage-text-color: "F4F6F7"
+titlepage-rule-color: "EDD369"
+keywords: [Lean, theorem proving, mathematics, math, maths, tutorial]
+...
 
-Authors in alphabetical order:
 
-* Arthur Paulino
-* Damiano Testa
-* Edward Ayers
-* Henrik Böving
-* Jannis Limperg
-* Siddhartha Gadgil
-* Siddharth Bhat
 -/

--- a/lean/cover.lean
+++ b/lean/cover.lean
@@ -8,6 +8,7 @@ date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https
 mainfont: "DejaVu Serif"
 monofont: "DejaVu Sans Mono"
 book: true
+header-right: "."
 titlepage: true
 titlepage-color: "083045"
 titlepage-text-color: "F4F6F7"

--- a/md/cover.md
+++ b/md/cover.md
@@ -1,11 +1,15 @@
-# Lean 4 Metaprogramming Book
-
-Authors in alphabetical order:
-
-* Arthur Paulino
-* Damiano Testa
-* Edward Ayers
-* Henrik Böving
-* Jannis Limperg
-* Siddhartha Gadgil
-* Siddharth Bhat
+---
+title: "Metaprogramming in Lean 4"
+author: [Arthur Paulino, Damiano Testa, Edward Ayers, Henrik Böving,
+         Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
+# abusing this field just because the template puts it at a decent right-sized spot
+date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https://github.com/Wandmalfarbe/pandoc-latex-template)"
+mainfont: "DejaVu Serif"
+monofont: "DejaVu Sans Mono"
+book: true
+titlepage: true
+titlepage-color: "083045"
+titlepage-text-color: "F4F6F7"
+titlepage-rule-color: "EDD369"
+keywords: [Lean, theorem proving, mathematics, math, maths, tutorial]
+...

--- a/md/cover.md
+++ b/md/cover.md
@@ -7,6 +7,7 @@ date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https
 mainfont: "DejaVu Serif"
 monofont: "DejaVu Sans Mono"
 book: true
+header-right: "."
 titlepage: true
 titlepage-color: "083045"
 titlepage-text-color: "F4F6F7"

--- a/pygments/lean4.py
+++ b/pygments/lean4.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.theorem
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for theorem-proving languages.
+
+    :copyright: Copyright 2006-2017 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, default, words
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Generic
+
+__all__ = ['Lean4Lexer']
+
+class Lean4Lexer(RegexLexer):
+    """
+    For the `Lean 4 <https://github.com/leanprover/lean4>`_
+    theorem prover.
+
+    .. versionadded:: 2.0
+    """
+    name = 'Lean4'
+    aliases = ['lean4']
+    filenames = ['*.lean']
+    mimetypes = ['text/x-lean']
+
+    flags = re.MULTILINE | re.UNICODE
+
+    keywords1 = (
+        'import', 'abbreviation', 'opaque_hint', 'tactic_hint', 'definition',
+        'renaming', 'inline', 'hiding', 'exposing', 'parameter', 'parameters',
+        'conjecture', 'hypothesis', 'lemma', 'corollary', 'variable', 'variables',
+        'theorem', 'axiom', 'inductive', 'structure', 'universe', 'alias',
+        'help', 'options', 'precedence', 'postfix', 'prefix', 'calc_trans',
+        'calc_subst', 'calc_refl', 'infix', 'infixl', 'infixr', 'notation', '#eval',
+        '#check', '#reduce', '#exit', 'coercion', 'end', 'private', 'using', 'namespace',
+        'including', 'instance', 'section', 'context', 'protected', 'expose',
+        'export', 'set_option', 'add_rewrite', 'extends', 'open', 'example',
+        'constant', 'constants', 'print', 'opaque', 'reducible', 'irreducible',
+        'def', 'macro', 'elab', 'syntax', 'macro_rules', 'reduce', 'where',
+        'abbrev', 'noncomputable', 'class', 'attribute', 'synth', 'mutual',
+    )
+
+    keywords2 = (
+        'forall', 'fun', 'Pi', 'obtain', 'from', 'have', 'show', 'assume',
+        'take', 'let', 'if', 'else', 'then', 'by', 'in', 'with', 'begin',
+        'proof', 'qed', 'calc', 'match', 'nomatch', 'do', 'at',
+    )
+
+    keywords3 = (
+        # Sorts
+        'Type', 'Prop', 'Sort',
+    )
+
+    operators = (
+        u'!=', u'#', u'&', u'&&', u'*', u'+', u'-', u'/', u'@', u'!', u'`',
+        u'-.', u'->', u'.', u'..', u'...', u'::', u':>', u';', u';;', u'<',
+        u'<-', u'=', u'==', u'>', u'_', u'|', u'||', u'~', u'=>', u'<=', u'>=',
+        u'/\\', u'\\/', u'∀', u'Π', u'λ', u'↔', u'∧', u'∨', u'≠', u'≤', u'≥',
+        u'¬', u'⁻¹', u'⬝', u'▸', u'→', u'∃', u'ℕ', u'ℤ', u'≈', u'×', u'⌞',
+        u'⌟', u'≡', u'⟨', u'⟩',
+    )
+
+    punctuation = (u'(', u')', u':', u'{', u'}', u'[', u']', u'⦃', u'⦄',
+                   u':=', u',')
+
+    tokens = {
+        'root': [
+            (r'\s+', Text),
+            (r'/-', Comment, 'comment'),
+            (r'--.*?$', Comment.Single),
+            (words(keywords1, prefix=r'\b', suffix=r'\b'), Keyword.Namespace),
+            (words(keywords2, prefix=r'\b', suffix=r'\b'), Keyword),
+            (words(keywords3, prefix=r'\b', suffix=r'\b'), Keyword.Type),
+            (words(operators), Name.Builtin.Pseudo),
+            (words(punctuation), Operator),
+            (u"[A-Za-z_\u03b1-\u03ba\u03bc-\u03fb\u1f00-\u1ffe\u2100-\u214f]"
+             u"[A-Za-z_'\u03b1-\u03ba\u03bc-\u03fb\u1f00-\u1ffe\u2070-\u2079"
+             u"\u207f-\u2089\u2090-\u209c\u2100-\u214f0-9]*", Name),
+            (r'\d+', Number.Integer),
+            (r'"', String.Double, 'string'),
+            (r'[~?][a-z][\w\']*:', Name.Variable)
+        ],
+        'comment': [
+            # Multiline Comments
+            (r'[^/-]', Comment.Multiline),
+            (r'/-', Comment.Multiline, '#push'),
+            (r'-/', Comment.Multiline, '#pop'),
+            (r'[/-]', Comment.Multiline)
+        ],
+        'string': [
+            (r'[^\\"]+', String.Double),
+            (r'\\[n"\\]', String.Escape),
+            ('"', String.Double, '#pop'),
+        ],
+    }


### PR DESCRIPTION
There are at least 2 ways to publish an artifact here -- one with [actions/upload-artifact](https://github.com/actions/upload-artifact), and the other what I've done in the PR -- with a release (one that continually self-updates). The advantage of the latter is that the PDF is immediately openable in a browser. See e.g. https://github.com/Julian/lean4-metaprogramming-book/releases/tag/latest. The disadvantage is that this means every time someone pulls, a `latest` tag will have been updated.

Obviously comments welcome if you prefer the other way.

As-is though, I set this to rebuild a PDF each time a PR or push to master is made.