### PR TITLE
Unify spelling of "metavariable"

### DIFF
--- a/lean/main/cheat-sheet.lean
+++ b/lean/main/cheat-sheet.lean
@@ -6,10 +6,10 @@
 * Extract the goal: `Lean.Elab.Tactic.getMainGoal`
 
   Use as `let goal ← Lean.Elab.Tactic.getMainGoal`
-* Extract the declaration out of a meta-variable: `Lean.Meta.getMVarDecl mvar`
+* Extract the declaration out of a metavariable: `Lean.Meta.getMVarDecl mvar`
   when `mvar : Lean.MVarId` is in context.
   For instance, `mvar` could be the goal extracted using `getMainGoal`
-* Extract the type of a meta-variable: `Lean.MetavarDecl.type mvdecl`
+* Extract the type of a metavariable: `Lean.MetavarDecl.type mvdecl`
   when `mvdecl : Lean.MetavarDecl` is in context.
 * Extract the type of the main goal: `Lean.Elab.Tactic.getMainTarget`
 

--- a/lean/main/elaboration.lean
+++ b/lean/main/elaboration.lean
@@ -220,17 +220,17 @@ can do during its execution.
 A term elaborator may throw `Except.postpone`. This indicates that
 the term elaborator requires more
 information to continue its work. In order to represent this missing information,
-Lean uses so called synthetic meta variables. As you know from before, metavariables
-are holes in `Expr`s that are waiting to be filled in. Synthetic meta variables are 
+Lean uses so called synthetic metavariables. As you know from before, metavariables
+are holes in `Expr`s that are waiting to be filled in. Synthetic metavariables are
 different in that they have special methods that are used to solve them,
 registered in `SyntheticMVarKind`. Right now, there are four of these:
-- `typeClass`, the meta variable should be solved with typeclass synthesis
-- `coe`, the meta variable should be solved via coercion (a special case of typeclass)
-- `tactic`, the meta variable is a tactic term that should be solved by running a tactic
+- `typeClass`, the metavariable should be solved with typeclass synthesis
+- `coe`, the metavariable should be solved via coercion (a special case of typeclass)
+- `tactic`, the metavariable is a tactic term that should be solved by running a tactic
 - `postponed`, the ones that are created at `Except.postpone`
 
-Once such a synthetic meta variable is created, the next higher level term elaborator will continue.
-At some point, execution of postponed meta variables will be resumed by the term elaborator,
+Once such a synthetic metavariable is created, the next higher level term elaborator will continue.
+At some point, execution of postponed metavariables will be resumed by the term elaborator,
 in hopes that it can now complete its execution. We can try to see this in
 action with the following example:
 -/
@@ -238,7 +238,7 @@ action with the following example:
 
 /-!
 What happened here is that the elaborator for function applications started
-at `List.foldr` which is a generic function so it created meta variables
+at `List.foldr` which is a generic function so it created metavariables
 for the implicit type parameters. Then, it attempted to elaborate the first argument `.add`.
 
 In case you don't know how `.name` works, the basic idea is that quite
@@ -249,9 +249,9 @@ useful when you want to use constructors of a type without referring to its
 namespace or opening it, but can also be used like above.
 
 Now back to our example, while Lean does at this point already know that `.add`
-needs to have type: `?m1 → ?m2 → ?m2` (where `?x` is notation for a meta variable)
+needs to have type: `?m1 → ?m2 → ?m2` (where `?x` is notation for a metavariable)
 the elaborator for `.add` does need to know the actual value of `?m2` so the
-term elaborator postpones execution (by internally creating a synthetic meta variable
+term elaborator postpones execution (by internally creating a synthetic metavariable
 in place of `.add`), the elaboration of the other two arguments then yields the fact that
 `?m2` has to be `Nat` so once the `.add` elaborator is continued it can work with
 this information to complete elaboration.
@@ -308,8 +308,8 @@ def getCtors (typ : Name) : MetaM (List Name) := do
 
 @[termElab myanon]
 def myanonImpl : TermElab := fun stx typ? => do
-  -- Attempt to postpone execution if the type is not known or is a meta variable.
-  -- Meta variables are used by things like the function elaborator to fill
+  -- Attempt to postpone execution if the type is not known or is a metavariable.
+  -- Metavariables are used by things like the function elaborator to fill
   -- out the values of implicit parameters when they haven't gained enough
   -- information to figure them out yet.
   -- Term elaborators can only postpone execution once, so the elaborator

--- a/lean/main/expressions.lean
+++ b/lean/main/expressions.lean
@@ -23,7 +23,7 @@ namespace Playground
 inductive Expr where
   | bvar    : Nat → Data → Expr                       -- bound variables
   | fvar    : FVarId → Data → Expr                    -- free variables
-  | mvar    : MVarId → Data → Expr                    -- meta variables
+  | mvar    : MVarId → Data → Expr                    -- metavariables
   | sort    : Level → Data → Expr                     -- Sort
   | const   : Name → List Level → Data → Expr         -- constants
   | app     : Expr → Expr → Data → Expr               -- application

--- a/lean/main/metam.lean
+++ b/lean/main/metam.lean
@@ -120,25 +120,25 @@ elab "myProp" : term => propM
 #reduce myProp Nat.succ -- ∀ (n : Nat), Nat.succ n = Nat.succ (Nat.succ n)
 
 /-!
-## Meta variables
+## Metavariables
 
-Meta-variables are variables that can be created and assigned to only at the
+Metavariables are variables that can be created and assigned to only at the
 meta level, and not the object/term level. They are used principally as
 placeholders, especially for goals. They can be assigned expressions in terms of
-other meta variables. However, before being assigned to a pure (i.e., not meta)
+other metavariables. However, before being assigned to a pure (i.e., not meta)
 definition, the assignments should be resolvable to a value not involving
-meta-variables.
+metavariables.
 
-One way to create a meta-variable representing an expression is to use the
-`mkFreshExprMVar` function. This function creates a meta-variable that can be
-assigned an expression. One can optionally specify a type for the meta-variable.
-In the example below, we create three meta-variables, `mvar1`, `mvar2`, and
+One way to create a metavariable representing an expression is to use the
+`mkFreshExprMVar` function. This function creates a metavariable that can be
+assigned an expression. One can optionally specify a type for the metavariable.
+In the example below, we create three metavariables, `mvar1`, `mvar2`, and
 `mvar3`, with `mvar1` and `mvar3` assigned type `Nat` and `mvar2` assigned the
 type `Nat → Nat`.
 
-We assign expressions to the meta-variables using the `assignExprMVar` function.
-Like many functions dealing with meta-variables, this takes the id of the
-meta-variable as an argument. Below we assign to `mvar1` the result of function
+We assign expressions to the metavariables using the `assignExprMVar` function.
+Like many functions dealing with metavariables, this takes the id of the
+metavariable as an argument. Below we assign to `mvar1` the result of function
 application of `mvar2` to `mvar3`. We then assign to `mvar2` the constant
 expression `Nat.succ` and to `mvar3` the constant expression `Nat.zero`. Clearly
 this means we have assigned `Nat.succ (Nat.zero)`, i.e., `1` to `mvar1`. We


### PR DESCRIPTION
The book used to contain "metavariable", "meta variable" and
"meta-variable". We now consistenly use "metavariable", which is the
spelling used in Lean 4.
