### PR TITLE
Address Patrick's comments regarding syntax and macros

### DIFF
--- a/lean/main/macros.lean
+++ b/lean/main/macros.lean
@@ -175,11 +175,26 @@ in order to use macros, if you want you can just keep in mind that Lean
 will not allow name clashes like the one in the `const` example.
 
 ## `MonadQuotation` and `MonadRef`
-This macro hygiene mechanism is the reason that while we are able to use pattern
-matching on syntax with `` `(syntax) `` we cannot just create `Syntax` with the same
-syntax in pure functions: someone has to keep track of macro scopes for us.
-In this case, this is done by the `MacroM` monad, but it can be done by any monad that
-implements `Lean.MonadQuotation`.  For this reason, it's worth to take a brief look at it:
+Based on this description of the hygiene mechanism one interesting
+quesiton pops up, how do we know what the current list of macro scopes
+actually is? After all in the macro functions that were defined above
+there is never any explicit passing around of the scopes happening.
+As is quite common in functional programming, as soon as we start
+having some additional state that we need to bookkeep (like the macro scopes)
+this is done with a monad, this is the case here as well with a slight twist.
+
+Instead of implementing this for only a single monad `MacroM` the general
+concept of keeping track of macro scopes in monadic way is abstracted
+away using a type class called `MonadQuotation`. This allows any other
+monad to also easily provide this hygienic `Syntax` creation mechanism
+by simply implementing this type class.
+
+This is also the reason that while we are able to use pattern matching on syntax
+with `` `(syntax) `` we cannot just create `Syntax` with the same
+syntax in pure functions: there is no `Monad` implementing `MonadQuotation`
+involved in order to keep track of the macro scopes.
+
+Now let's take a brief look at the `MonadQuotation` type class:
 -/
 
 namespace Playground

--- a/lean/main/macros.lean
+++ b/lean/main/macros.lean
@@ -295,18 +295,17 @@ arith language using some special syntax or whatever else comes to your mind.
 As promised in the syntax chapter here is Binders 2.0. We'll start by
 reintroducing our theory of sets:
 -/
-abbrev Set (α : Type u) := α → Prop
-abbrev Set.mem (x : α) (X : Set α) : Prop := X x
--- We bind the `s` and the notation this way so `x ∈ S ∧ ... is parsed as as:
--- `(x ∈ (S)) ∧ ...`
--- as opposed to:
--- `x ∈ (S ∧ ...)`
-notation:100 x " ∈ " s:99 => Set.mem x s
+def Set (α : Type u) := α → Prop
+def Set.mem (x : α) (X : Set α) : Prop := X x
+
+-- Integrate into the already existing typeclass for membership notation
+instance : Membership α (Set α) where
+  mem := Set.mem
 
 def Set.empty : Set α := λ _ => False
 
 -- the basic "all elements such that" function for the notation
-abbrev setOf {α : Type} (p : α → Prop) : Set α := p
+def setOf {α : Type} (p : α → Prop) : Set α := p
 
 /-!
 The goal for this section will be to allow for both `{x : X | p x}`
@@ -333,14 +332,14 @@ And finally the macros to expand our syntax:
 -/
 
 macro_rules
-  | `({ $id:ident : $ty:term | $body:term }) => `(setOf (fun ($id : $ty) => $body))
-  | `({ $id:ident ∈ $s:term | $body:term }) => `(setOf (fun $id => $id ∈ $s ∧ $body))
+  | `({ $var:ident : $ty:term | $body:term }) => `(setOf (fun ($var : $ty) => $body))
+  | `({ $var:ident ∈ $s:term | $body:term }) => `(setOf (fun $var => $var ∈ $s ∧ $body))
 
 -- Old examples with better syntax:
-#check { x : Nat | x ≤ 1} -- setOf fun x => x ≤ 1 : Set Nat
+#check { x : Nat | x ≤ 1 } -- setOf fun x => x ≤ 1 : Set Nat
 
-example : 1 ∈ { y : Nat | y ≤ 1} := by decide
-example : 2 ∈ { y : Nat | y ≤ 3 ∧ 1 ≤ y} := by decide
+example : 1 ∈ { y : Nat | y ≤ 1 } := by simp[Membership.mem, Set.mem, setOf]
+example : 2 ∈ { y : Nat | y ≤ 3 ∧ 1 ≤ y } := by simp[Membership.mem, Set.mem, setOf]
 
 -- New examples:
 def oneSet : Set Nat := λ x => x = 1
@@ -362,6 +361,6 @@ If you want to know more about macros you can read:
 - the API docs: TODO link
 - the source code: the lower parts of [Init.Prelude](https://github.com/leanprover/lean4/blob/master/src/Init/Prelude.lean)
   as you can see they are declared quite early in Lean because of their importance
-  of to building up syntax
+  to building up syntax
 - the aforementioned [Beyond Notations](https://lmcs.episciences.org/9362/pdf) paper
 -/

--- a/lean/main/macros.lean
+++ b/lean/main/macros.lean
@@ -176,7 +176,7 @@ will not allow name clashes like the one in the `const` example.
 
 ## `MonadQuotation` and `MonadRef`
 Based on this description of the hygiene mechanism one interesting
-quesiton pops up, how do we know what the current list of macro scopes
+question pops up, how do we know what the current list of macro scopes
 actually is? After all in the macro functions that were defined above
 there is never any explicit passing around of the scopes happening.
 As is quite common in functional programming, as soon as we start

--- a/lean/main/syntax.lean
+++ b/lean/main/syntax.lean
@@ -43,8 +43,8 @@ and operate on them on the right hand side. It gets even better though, we can
 in theory create syntax with 0 up to as many parameters as we wish using the
 `notation` command, it is hence also often referred to as "mixfix" notation.
 
-The three unintuitive parts about these two are:
-- The fact that we are leaving spaces around our operators: " ⊕ ", " XOR ".
+The two unintuitive parts about these two are:
+- The fact that we are leaving spaces around our operators: " ⊕ ", " LXOR ".
   This is so that, when Lean pretty prints our syntax later on, it also
   uses spaces around the operators, otherwise the syntax would just be presented
   as `l⊕r` as opposed to `l ⊕ r`.

--- a/lean/main/syntax.lean
+++ b/lean/main/syntax.lean
@@ -57,7 +57,7 @@ The two unintuitive parts about these two are:
 #eval true ⊕ (false LXOR false) -- true
 
 /-!
-As you can see the Lean interpreter analyzed the first term without parentheses
+As we can see the Lean interpreter analyzed the first term without parentheses
 like the second instead of the third one. This is because the `⊕` notation
 has higher precedence than `LXOR` (`60 > 10` after all) and is thus evaluated before it.
 This is also how you might implement rules like `*` being evaluated before `+`.
@@ -65,21 +65,69 @@ This is also how you might implement rules like `*` being evaluated before `+`.
 Lastly at the `notation` example there are also these `:precedence` bindings
 at the arguments: `l:10` and `r:11`. This conveys that the left argument must have
 precedence at least 10 or greater, and the right argument must have precedence at 11
-or greater. This forces left associativity like `infixl` above. To understand this,
-let's compare two hypothetical parses:
-```
--- a LXOR b LXOR c
-(a:10 LXOR b:11):10 LXOR c
-a LXOR (b:10 LXOR c:11):10
-```
-In the parse tree of `(a:10 LXOR b:11):10 LXOR c`, we see that the right argument `(b LXOR c)`
-is given the precedence 10, because a rule is always given the lowest precedence of any of its
-subrules. However, the rule for `LXOR` expects the right argument to have a precedence of at
-least 11, as witnessed by the `r:11` at the right-hand-side of `notation:10 l:10 " LXOR " r:11`.
-Thus this rule ensures that `LXOR` is left associative.
+or greater. The way the arguments are assigned their respective precedence is by looking at
+the precedence of the rule that was used to parse them. Consider for example
+`a LXOR b LXOR c`. Theoretically speaking this could be parsed in two ways:
+1. `(a LXOR b) LXOR c`
+2. `a LXOR (b LXOR c)`
 
-Can you make it right associative?
+Since the arguments in parenthesis are parsed by the `LXOR` rule with precedence
+10 they will appear as arguments with precedence 10 to the outer `LXOR` rule:
+1. `(a LXOR b):10 LXOR c`
+2. `a LXOR (b LXOR c):10`
 
+However if we check the definition of `LXOR`: `notation:10 l:10 " LXOR " r:11`
+we can see that the right hand side argument requires a precedence of at least 11
+or greater, thus the second parse is invalid and we remain with: `(a LXOR b) LXOR c`
+assuming that:
+- `a` has precedence 10 or higher
+- `b` has precedence 11 or higher
+- `c` has precedence 11 or higher
+
+Thus `LXOR` is a left associative notation. Can you make it right associative?
+
+NOTE: If parameters of a notation are not explicitly given a precedence they will implicitly be tagged with precedence 0.
+
+As a last remark for this section: Lean will always attempt to obtain the longest
+matching parse possible, this has three important implications.
+First a very intuitive one, if we have a right associative operator `+`
+and Lean sees something like `a + b + c`, it will first parse the `a + b`
+and then attempt to keep parsing (as long as precedence allows it) until
+it cannot continue anymore. Hence Lean will parse this expression as `a + (b + c)`.
+
+Secondly if we have a notation where precedence does not allow to figure
+out how the expression should be parenthesized, for example:
+-/
+
+notation:65 lhs:65 " ~ " rhs:65 => (lhs - rhs)
+
+/-!
+An expression like `a ~ b ~ c` will be parsed as `a ~ (b ~ c)` because
+Lean attempts to find the longest parse possible. As a general rule of thumb:
+If precedence is ambiguous Lean will default to right associativity.
+-/
+
+#eval 5 ~ 3 ~ 3 -- 5 because this is parsed as 5 - (3 - 3)
+
+/-!
+Lastly, if we define overlapping notation such as:
+-/
+
+notation:65 a " + " b:66 " + " c:66 => a + b - c
+
+/-!
+Lean will prefer this notation over parsing `a + b + c` as two additions ,
+that is `1 + 2 + 3` will evaluate to 0 now:
+-/
+
+#eval 1 + 2 + 3  -- 0
+
+/-!
+This is again because it is looking for the longest possible parser which
+is in this case the one that accepts two `+` at once instead of only one.
+-/
+
+/-!
 ### Free form syntax declarations
 With the above `infix` and `notation` commands you can get quite far with
 declaring ordinary mathematical syntax already. Lean does however allow you to
@@ -113,6 +161,8 @@ give meaning to this syntax, is topic of the elaboration and macro chapter.
 An example of one we have already seen however would be the `notation` and
 `infix` command.
 
+NOTE: All the principles from `notation` and `infix` regarding precedence fully apply to `syntax`
+
 We can of course also involve other syntax into our own declarations
 in order to build up syntax trees, for example we could try to build our
 own little boolean expression language:
@@ -140,8 +190,8 @@ syntax category on top. This is done using the `declare_syntax_cat` command:
 declare_syntax_cat boolean_expr
 syntax "⊥" : boolean_expr -- ⊥ for false
 syntax "⊤" : boolean_expr -- ⊤ for true
-syntax boolean_expr " OR " boolean_expr : boolean_expr
-syntax boolean_expr " AND " boolean_expr : boolean_expr
+syntax:40 boolean_expr " OR " boolean_expr : boolean_expr
+syntax:50 boolean_expr " AND " boolean_expr : boolean_expr
 
 /-!
 Now that we are working in our own syntax category, we are completely

--- a/md/main/syntax.md
+++ b/md/main/syntax.md
@@ -44,8 +44,8 @@ and operate on them on the right hand side. It gets even better though, we can
 in theory create syntax with 0 up to as many parameters as we wish using the
 `notation` command, it is hence also often referred to as "mixfix" notation.
 
-The three unintuitive parts about these two are:
-- The fact that we are leaving spaces around our operators: " ⊕ ", " XOR ".
+The two unintuitive parts about these two are:
+- The fact that we are leaving spaces around our operators: " ⊕ ", " LXOR ".
   This is so that, when Lean pretty prints our syntax later on, it also
   uses spaces around the operators, otherwise the syntax would just be presented
   as `l⊕r` as opposed to `l ⊕ r`.
@@ -399,3 +399,91 @@ def test : Elab.TermElabM Nat := do
 Feel free to play around with this example and extend it in whatever way
 you want to. The next chapters will mostly be about functions that operate
 on `Syntax` in some way.
+
+## More elaborate examples
+### Using type classes for notations
+We can use type classes in order to add notation that is extensible via
+the type instead of the syntax system, this is for example how `+`
+using the typeclasses `HAdd` and `Add` and other common operators in
+Lean are generically defined.
+
+For example we might want to have a generic notation for subset notation.
+The first thing we have to do is define a type class that captures
+the function we want to build notation for.
+
+```lean
+class Subset (α : Type u) where
+  subset : α → α → Prop
+```
+
+The second step is to define the notation, what we can do here is simply
+turn every instance of a `⊆` appearing in the code to a call to `Subset.subset`
+because the type class resolution should be able to figure out which `Subset`
+instance is referred to. Thus the notation will be a simple:
+
+```lean
+-- precedence is arbitrary for this example
+infix:50 " ⊆ " => Subset.subset
+```
+
+Let's define a simple theory of sets to test it:
+
+```lean
+-- a `Set` is defined by the elements it contains
+-- -> a simple predicate on the type of its elements
+abbrev Set (α : Type u) := α → Prop
+
+abbrev Set.mem (x : α) (X : Set α) : Prop := X x
+
+-- We bind the `s` and the notation this way so `x ∈ S ∧ ... is parsed as as:
+-- `(x ∈ (S)) ∧ ...`
+-- as opposed to:
+-- `x ∈ (S ∧ ...)`
+notation:100 x " ∈ " s:99 => Set.mem x s
+
+def Set.empty : Set α := λ _ => False
+
+instance : Subset (Set α) where
+  subset X Y := ∀ (x : α), x ∈ X → x ∈ Y
+
+example : ∀ (X : Set α), Set.empty ⊆ X:= by
+  intro X x
+  -- ⊢ Set.mem x (Set.empty α) → Set.mem x X
+  intro h
+  exact False.elim h -- empty set has no members
+```
+
+### Binders
+Because declaring syntax that uses variable binders used to be quite a
+weird thing to do in Lean 3 we'll take a brief look at how naturally
+this can be done in Lean 4.
+
+For this example we will define the well known notation for the set
+that contains all elements `x` such that some property holds:
+`{x ∈ ℕ | x < 10}` for example.
+
+First things first we need to extend the theory of sets from above slightly:
+
+```lean
+-- the basic "all elements such that" function for the notation
+abbrev setOf {α : Type} (p : α → Prop) : Set α := p
+```
+
+Equipped with this function we can now attempt to intuitively define a
+basic version of our notation:
+
+```lean
+notation "{" x "|" p "}" => setOf (fun x => p)
+
+#check { (x : Nat) | x ≤ 1} -- setOf fun x => x ≤ 1 : Set Nat
+
+example : 1 ∈ { (y : Nat) | y ≤ 1} := by decide
+example : 2 ∈ { (y : Nat) | y ≤ 3 ∧ 1 ≤ y} := by decide
+```
+
+This intuitive notation will indeed deal with what we could throw at
+it in the way we would expect it.
+
+As to how one might extend this notation to allow more set theoretic
+things such as `{x ∈ X | p x}` and leave away the parenthesis around
+the bound variables, we refer the reader to the macro chapter.

--- a/md/main/syntax.md
+++ b/md/main/syntax.md
@@ -91,10 +91,11 @@ NOTE: If parameters of a notation are not explicitly given a precedence they wil
 
 As a last remark for this section: Lean will always attempt to obtain the longest
 matching parse possible, this has three important implications.
-First a very intuitive one, if we have a right associative operator `+`
-and Lean sees something like `a + b + c`, it will first parse the `a + b`
+First a very intuitive one, if we have a right associative operator `^`
+and Lean sees something like `a ^ b ^ c`, it will first parse the `a ^ b`
 and then attempt to keep parsing (as long as precedence allows it) until
-it cannot continue anymore. Hence Lean will parse this expression as `a + (b + c)`.
+it cannot continue anymore. Hence Lean will parse this expression as `a ^ (b ^ c)`
+(as we would expect it to).
 
 Secondly if we have a notation where precedence does not allow to figure
 out how the expression should be parenthesized, for example:
@@ -114,18 +115,20 @@ If precedence is ambiguous Lean will default to right associativity.
 Lastly, if we define overlapping notation such as:
 
 ```lean
-notation:65 a " + " b:66 " + " c:66 => a + b - c
+-- define `a ~ b mod rel` to mean that a and b are equivalent with respect to some equivalance relation rel
+notation:65 a:65 " ~ " b:65 " mod " rel:65 => rel a b
 ```
 
-Lean will prefer this notation over parsing `a + b + c` as two additions ,
-that is `1 + 2 + 3` will evaluate to 0 now:
+Lean will prefer this notation over parsing `a ~ b` as defined above and
+then erroring because it doesn't know what to do with `mod` and the
+relation argument:
 
 ```lean
-#eval 1 + 2 + 3  -- 0
+#check 0 ~ 0 mod Eq -- 0 = 0 : Prop
 ```
 
 This is again because it is looking for the longest possible parser which
-is in this case the one that accepts two `+` at once instead of only one.
+in this case involves also consuming `mod` and the relation argument.
 
 ### Free form syntax declarations
 With the above `infix` and `notation` commands you can get quite far with
@@ -479,15 +482,13 @@ Let's define a simple theory of sets to test it:
 ```lean
 -- a `Set` is defined by the elements it contains
 -- -> a simple predicate on the type of its elements
-abbrev Set (α : Type u) := α → Prop
+def Set (α : Type u) := α → Prop
 
-abbrev Set.mem (x : α) (X : Set α) : Prop := X x
+def Set.mem (x : α) (X : Set α) : Prop := X x
 
--- We bind the `s` and the notation this way so `x ∈ S ∧ ... is parsed as as:
--- `(x ∈ (S)) ∧ ...`
--- as opposed to:
--- `x ∈ (S ∧ ...)`
-notation:100 x " ∈ " s:99 => Set.mem x s
+-- Integrate into the already existing typeclass for membership notation
+instance : Membership α (Set α) where
+  mem := Set.mem
 
 def Set.empty : Set α := λ _ => False
 
@@ -496,14 +497,14 @@ instance : Subset (Set α) where
 
 example : ∀ (X : Set α), Set.empty ⊆ X:= by
   intro X x
-  -- ⊢ Set.mem x (Set.empty α) → Set.mem x X
+  -- ⊢ x ∈ Set.empty → x ∈ X
   intro h
   exact False.elim h -- empty set has no members
 ```
 
 ### Binders
-Because declaring syntax that uses variable binders used to be quite a
-weird thing to do in Lean 3 we'll take a brief look at how naturally
+Because declaring syntax that uses variable binders used to be a rather
+unintuitive thing to do in Lean 3 we'll take a brief look at how naturally
 this can be done in Lean 4.
 
 For this example we will define the well known notation for the set
@@ -514,7 +515,7 @@ First things first we need to extend the theory of sets from above slightly:
 
 ```lean
 -- the basic "all elements such that" function for the notation
-abbrev setOf {α : Type} (p : α → Prop) : Set α := p
+def setOf {α : Type} (p : α → Prop) : Set α := p
 ```
 
 Equipped with this function we can now attempt to intuitively define a
@@ -523,10 +524,10 @@ basic version of our notation:
 ```lean
 notation "{" x "|" p "}" => setOf (fun x => p)
 
-#check { (x : Nat) | x ≤ 1} -- setOf fun x => x ≤ 1 : Set Nat
+#check { (x : Nat) | x ≤ 1 } -- setOf fun x => x ≤ 1 : Set Nat
 
-example : 1 ∈ { (y : Nat) | y ≤ 1} := by decide
-example : 2 ∈ { (y : Nat) | y ≤ 3 ∧ 1 ≤ y} := by decide
+example : 1 ∈ { (y : Nat) | y ≤ 1 } := by simp[Membership.mem, Set.mem, setOf]
+example : 2 ∈ { (y : Nat) | y ≤ 3 ∧ 1 ≤ y } := by simp[Membership.mem, Set.mem, setOf]
 ```
 
 This intuitive notation will indeed deal with what we could throw at

--- a/md/main/syntax.md
+++ b/md/main/syntax.md
@@ -58,7 +58,7 @@ The two unintuitive parts about these two are:
 #eval true ⊕ (false LXOR false) -- true
 ```
 
-As you can see the Lean interpreter analyzed the first term without parentheses
+As we can see the Lean interpreter analyzed the first term without parentheses
 like the second instead of the third one. This is because the `⊕` notation
 has higher precedence than `LXOR` (`60 > 10` after all) and is thus evaluated before it.
 This is also how you might implement rules like `*` being evaluated before `+`.
@@ -66,20 +66,66 @@ This is also how you might implement rules like `*` being evaluated before `+`.
 Lastly at the `notation` example there are also these `:precedence` bindings
 at the arguments: `l:10` and `r:11`. This conveys that the left argument must have
 precedence at least 10 or greater, and the right argument must have precedence at 11
-or greater. This forces left associativity like `infixl` above. To understand this,
-let's compare two hypothetical parses:
-```
--- a LXOR b LXOR c
-(a:10 LXOR b:11):10 LXOR c
-a LXOR (b:10 LXOR c:11):10
-```
-In the parse tree of `(a:10 LXOR b:11):10 LXOR c`, we see that the right argument `(b LXOR c)`
-is given the precedence 10, because a rule is always given the lowest precedence of any of its
-subrules. However, the rule for `LXOR` expects the right argument to have a precedence of at
-least 11, as witnessed by the `r:11` at the right-hand-side of `notation:10 l:10 " LXOR " r:11`.
-Thus this rule ensures that `LXOR` is left associative.
+or greater. The way the arguments are assigned their respective precedence is by looking at
+the precedence of the rule that was used to parse them. Consider for example
+`a LXOR b LXOR c`. Theoretically speaking this could be parsed in two ways:
+1. `(a LXOR b) LXOR c`
+2. `a LXOR (b LXOR c)`
 
-Can you make it right associative?
+Since the arguments in parenthesis are parsed by the `LXOR` rule with precedence
+10 they will appear as arguments with precedence 10 to the outer `LXOR` rule:
+1. `(a LXOR b):10 LXOR c`
+2. `a LXOR (b LXOR c):10`
+
+However if we check the definition of `LXOR`: `notation:10 l:10 " LXOR " r:11`
+we can see that the right hand side argument requires a precedence of at least 11
+or greater, thus the second parse is invalid and we remain with: `(a LXOR b) LXOR c`
+assuming that:
+- `a` has precedence 10 or higher
+- `b` has precedence 11 or higher
+- `c` has precedence 11 or higher
+
+Thus `LXOR` is a left associative notation. Can you make it right associative?
+
+NOTE: If parameters of a notation are not explicitly given a precedence they will implicitly be tagged with precedence 0.
+
+As a last remark for this section: Lean will always attempt to obtain the longest
+matching parse possible, this has three important implications.
+First a very intuitive one, if we have a right associative operator `+`
+and Lean sees something like `a + b + c`, it will first parse the `a + b`
+and then attempt to keep parsing (as long as precedence allows it) until
+it cannot continue anymore. Hence Lean will parse this expression as `a + (b + c)`.
+
+Secondly if we have a notation where precedence does not allow to figure
+out how the expression should be parenthesized, for example:
+
+```lean
+notation:65 lhs:65 " ~ " rhs:65 => (lhs - rhs)
+```
+
+An expression like `a ~ b ~ c` will be parsed as `a ~ (b ~ c)` because
+Lean attempts to find the longest parse possible. As a general rule of thumb:
+If precedence is ambiguous Lean will default to right associativity.
+
+```lean
+#eval 5 ~ 3 ~ 3 -- 5 because this is parsed as 5 - (3 - 3)
+```
+
+Lastly, if we define overlapping notation such as:
+
+```lean
+notation:65 a " + " b:66 " + " c:66 => a + b - c
+```
+
+Lean will prefer this notation over parsing `a + b + c` as two additions ,
+that is `1 + 2 + 3` will evaluate to 0 now:
+
+```lean
+#eval 1 + 2 + 3  -- 0
+```
+
+This is again because it is looking for the longest possible parser which
+is in this case the one that accepts two `+` at once instead of only one.
 
 ### Free form syntax declarations
 With the above `infix` and `notation` commands you can get quite far with
@@ -114,6 +160,8 @@ give meaning to this syntax, is topic of the elaboration and macro chapter.
 An example of one we have already seen however would be the `notation` and
 `infix` command.
 
+NOTE: All the principles from `notation` and `infix` regarding precedence fully apply to `syntax`
+
 We can of course also involve other syntax into our own declarations
 in order to build up syntax trees, for example we could try to build our
 own little boolean expression language:
@@ -141,8 +189,8 @@ syntax category on top. This is done using the `declare_syntax_cat` command:
 declare_syntax_cat boolean_expr
 syntax "⊥" : boolean_expr -- ⊥ for false
 syntax "⊤" : boolean_expr -- ⊤ for true
-syntax boolean_expr " OR " boolean_expr : boolean_expr
-syntax boolean_expr " AND " boolean_expr : boolean_expr
+syntax:40 boolean_expr " OR " boolean_expr : boolean_expr
+syntax:50 boolean_expr " AND " boolean_expr : boolean_expr
 ```
 
 Now that we are working in our own syntax category, we are completely


### PR DESCRIPTION
This addresses Patrick's comments from #39 regarding syntax and macros, in particular:
- [x] Syntax with binder notation
- [x] Explanation for the need of the `MonadQuotation` mechnaism
- [x] Precedence