### PR TITLE
Tweak the PDF build a bit

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,6 +28,7 @@ jobs:
       run: lualatex -shell-escape out.tex && lualatex -shell-escape out.tex
 
     - name: Rename
+      # Minted doesn't like filenames with spaces in them unfortunately, so we mv.
       run: mv out.tex 'Metaprogramming in Lean 4.tex' && mv out.pdf 'Metaprogramming in Lean 4.pdf'
 
     - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   book:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
     - name: Install Dependencies
-      run: brew install pandoc mactex-no-gui homebrew/homebrew-cask-fonts/font-dejavu pygments
+      run: sudo apt install -y pandoc texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-luatex fonts-dejavu python3-pygments
 
     - name: Download the Book Template
       run: |
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build a PDF
       # Running twice appears to be necessary to not get a blank TOC?!
-      run: /Library/TeX/texbin/lualatex -shell-escape out.tex && /Library/TeX/texbin/lualatex -shell-escape out.tex
+      run: lualatex -shell-escape out.tex && lualatex -shell-escape out.tex
 
     - name: Rename
       run: mv out.tex 'Metaprogramming in Lean 4.tex' && mv out.pdf 'Metaprogramming in Lean 4.pdf'

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,7 +1,6 @@
 name: Book
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -31,22 +30,11 @@ jobs:
     - name: Rename
       run: mv out.tex 'Metaprogramming in Lean 4.tex' && mv out.pdf 'Metaprogramming in Lean 4.pdf'
 
-    - name: Delete old release assets
-      uses: mknejp/delete-release-assets@v1
+    - uses: "marvinpinto/action-automatic-releases@latest"
       with:
-        token: ${{ github.token }}
-        tag: latest
-        fail-if-no-assets: false
-        fail-if-no-release: false
-        assets: |
-          *.tex
-          *.pdf
-
-    - name: Upload Outputs
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: latest
-        generate_release_notes: true
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        title: "Metaprogramming in Lean 4"
         files: |
           Metaprogramming in Lean 4.tex
           Metaprogramming in Lean 4.pdf


### PR DESCRIPTION
* Don't run on PR (right now someone sending a PR overrides the released book, even before it's merged)
* Re-release each time, rather than just updating artifacts on a static release
* Run on Ubuntu runners in CI which are a bit faster