### PR TITLE
metam: fix wrong explanation of WHNF

### DIFF
--- a/lean/main/metam.lean
+++ b/lean/main/metam.lean
@@ -184,10 +184,9 @@ form
 e = f x₁ ... xₙ   (n ≥ 0)
 ```
 
-and `f` is a data/type constructor or is irreducible (at the current transparency).
-To conveniently check the WHNF of an expression, we define a
-function `whnf'` which uses some advanced tech; don't worry about its
-implementation for now.
+and `f` cannot be reduced (at the current transparency). To conveniently check
+the WHNF of an expression, we define a function `whnf'` which uses some advanced
+tech; don't worry about its implementation for now.
 -/
 
 open Lean.Elab.Term in
@@ -203,50 +202,50 @@ Constructor applications are in WHNF (with some exceptions for numeric types):
 -/
 
 #eval whnf' `(List.cons 1 [])
--- [1]
+-- `[1]`
 
 /-!
 The *arguments* of an application in WHNF may or may not be in WHNF themselves:
 -/
 
 #eval whnf' `(List.cons (1 + 1) [])
--- [1 + 1]
+-- `[1 + 1]`
 
 /-!
 Applications of constants are in WHNF if the current transparency does not
 allow us to unfold the constants:
 -/
 
-#eval withTransparency .reducible $ whnf' `(List.append [1] [1])
--- List.append [1] [1]
+#eval withTransparency .reducible $ whnf' `(List.append [1] [2])
+-- `List.append [1] [2]`
 
 /-!
 Lambdas are in WHNF:
 -/
 
 #eval whnf' `(λ x : Nat => x)
--- fun x => x
+-- `fun x => x`
 
 /-!
 Foralls are in WHNF:
 -/
 
 #eval whnf' `(∀ x, x > 0)
--- ∀ (x : Nat), x > 0
+-- `∀ (x : Nat), x > 0`
 
 /-!
 Sorts are in WHNF:
 -/
 
 #eval whnf' `(Type 3)
--- Type 3
+-- `Type 3`
 
 /-!
 Literals are in WHNF:
 -/
 
 #eval whnf' `((15 : Nat))
--- 15
+-- `15`
 
 /-!
 Here are some more expressions in WHNF which are a bit tricky to test:
@@ -258,18 +257,25 @@ h 0 1   -- Assuming `h` is a local hypothesis, it is in WHNF.
 
 On the flipside, here are some expressions that are not in WHNF.
 
+Applications of constants are not in WHNF:
+-/
+
+#eval whnf' `(List.append [1])
+-- `fun x => 1 :: List.append [] x`
+
+/-!
+Applications of lambdas are not in WHNF:
+-/
+
+#eval whnf' `((λ x y : Nat => x + y) 1)
+-- `fun y => 1 + y`
+
+/-!
 `let` bindings are not in WHNF:
 -/
 
 #eval whnf' `(let x : Nat := 1; x)
 -- `1`
-
-/-!
-(Partial) applications of lambdas are not in WHNF:
--/
-
-#eval whnf' `((λ x y : Nat => x + y) 1)
--- `fun y => 1 + y`
 
 /-!
 And again some tricky examples:

--- a/lean/main/metam.lean
+++ b/lean/main/metam.lean
@@ -202,14 +202,14 @@ Constructor applications are in WHNF (with some exceptions for numeric types):
 -/
 
 #eval whnf' `(List.cons 1 [])
--- `[1]`
+-- [1]
 
 /-!
 The *arguments* of an application in WHNF may or may not be in WHNF themselves:
 -/
 
 #eval whnf' `(List.cons (1 + 1) [])
--- `[1 + 1]`
+-- [1 + 1]
 
 /-!
 Applications of constants are in WHNF if the current transparency does not
@@ -217,35 +217,35 @@ allow us to unfold the constants:
 -/
 
 #eval withTransparency .reducible $ whnf' `(List.append [1] [2])
--- `List.append [1] [2]`
+-- List.append [1] [2]
 
 /-!
 Lambdas are in WHNF:
 -/
 
 #eval whnf' `(λ x : Nat => x)
--- `fun x => x`
+-- fun x => x
 
 /-!
 Foralls are in WHNF:
 -/
 
 #eval whnf' `(∀ x, x > 0)
--- `∀ (x : Nat), x > 0`
+-- ∀ (x : Nat), x > 0
 
 /-!
 Sorts are in WHNF:
 -/
 
 #eval whnf' `(Type 3)
--- `Type 3`
+-- Type 3
 
 /-!
 Literals are in WHNF:
 -/
 
 #eval whnf' `((15 : Nat))
--- `15`
+-- 15
 
 /-!
 Here are some more expressions in WHNF which are a bit tricky to test:
@@ -261,7 +261,7 @@ Applications of constants are not in WHNF:
 -/
 
 #eval whnf' `(List.append [1])
--- `fun x => 1 :: List.append [] x`
+-- fun x => 1 :: List.append [] x
 
 /-!
 Applications of lambdas are not in WHNF:
@@ -275,7 +275,7 @@ Applications of lambdas are not in WHNF:
 -/
 
 #eval whnf' `(let x : Nat := 1; x)
--- `1`
+-- 1
 
 /-!
 And again some tricky examples:


### PR DESCRIPTION
Also some formatting fixes.

As discussed here: https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/.E2.9C.94.20WHNF.20of.20partially.20applied.20constants
