### PR TITLE
Update to latest Lean

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ inside the [lean](lean) directory.
 in Lean code blocks with `/- ... -/`. If you want to insert commentaries, do so
 with double dashes `--`.
 
+### Building the markdown files
+
 This is not required, but if you want to build the markdown files, you can do so
 by running `lake script run build`. It requires having Python installed, as well
 as the `lean2md` package.
+
+Or, if you have [viper](https://github.com/arthurpaulino/viper) installed and
+a linked environment that has `lean2md`, you can call
+`lake script run viper_build`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -30,7 +30,7 @@ script build do
 
   return 0
 
-script viperBuild do
+script viper_build do
   let _ ← runCmd "rm" #["-rf", "md"]
 
   if ← runCmd "viper" #["-m", "lean2md", "lean", "md"] then return 1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,13 @@ import Lake
 open Lake DSL
 
 package «lean4-metaprogramming-book» {
-  defaultFacet := PackageFacet.oleans
+  srcDir := "lean"
+  isLeanOnly := true
+}
+
+@[defaultTarget]
+lean_lib «lean4-metaprogramming-book» {
+  roots := #["cover"]
 }
 
 def runCmd (cmd : String) (args : Array String) : ScriptM Bool := do

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-05-04
+leanprover/lean4:nightly-2022-07-03

--- a/lean/extra/options.lean
+++ b/lean/extra/options.lean
@@ -61,7 +61,7 @@ To show this, let's write a command that prints the value of `pp.explicit`.
 elab "#getPPExplicit" : command => do
   let opts ← getOptions
   -- defValue = default value
-  Elab.logInfo s!"pp.explicit : {opts.get pp.explicit.name pp.explicit.defValue}"
+  logInfo s!"pp.explicit : {opts.get pp.explicit.name pp.explicit.defValue}"
 
 #getPPExplicit -- pp.explicit : false
 

--- a/lean/extra/pretty-printing.lean
+++ b/lean/extra/pretty-printing.lean
@@ -162,6 +162,12 @@ macro_rules
   | `([Lang| $x:ident]) => `(LangExpr.ident $(Lean.quote (toString x.getId)))
   | `([Lang| let $x:ident := $v:lang in $b:lang]) => `(LangExpr.letE $(Lean.quote (toString x.getId)) [Lang| $v] [Lang| $b])
 
+instance : Coe NumLit (TSyntax `lang) where
+  coe s := ⟨s.raw⟩
+
+instance : Coe Ident (TSyntax `lang) where
+  coe s := ⟨s.raw⟩
+
 -- LangExpr.letE "foo" (LangExpr.numConst 12)
 --   (LangExpr.letE "bar" (LangExpr.ident "foo") (LangExpr.ident "foo")) : LangExpr
 #check [Lang|
@@ -183,21 +189,17 @@ def unexpandNumConst : Unexpander
 @[appUnexpander LangExpr.ident]
 def unexpandIdent : Unexpander
   | `(LangExpr.ident $x:str) =>
-    if let some str := x.isStrLit? then
-      let name := mkIdent $ Name.mkSimple str
-      `([Lang| $name])
-    else
-      throw ()
+    let str := x.getString
+    let name := mkIdent $ Name.mkSimple str
+    `([Lang| $name])
   | _ => throw ()
 
 @[appUnexpander LangExpr.letE]
 def unexpandLet : Unexpander
   | `(LangExpr.letE $x:str [Lang| $v:lang] [Lang| $b:lang]) =>
-    if let some str := x.isStrLit? then
-      let name := mkIdent $ Name.mkSimple str
-      `([Lang| let $name := $v in $b])
-    else
-      throw ()
+    let str := x.getString
+    let name := mkIdent $ Name.mkSimple str
+    `([Lang| let $name := $v in $b])
   | _ => throw ()
 
 -- [Lang| let foo := 12 in foo] : LangExpr

--- a/lean/main/dsls.lean
+++ b/lean/main/dsls.lean
@@ -76,7 +76,7 @@ syntax "false"   : imp_lit
 def elabIMPLit : Syntax → MetaM Expr
   -- `mkAppM` creates an `Expr.app`, given the function `Name` and the args
   -- `mkNatLit` creates an `Expr` from a `Nat`
-  | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.toNat]
+  | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.getNat]
   -- `mkConst` creates an `Expr.const` given the constant `Name`
   | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.true]
   | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.false]

--- a/lean/main/elaboration.lean
+++ b/lean/main/elaboration.lean
@@ -156,7 +156,7 @@ elab "#findCElab " c:command : command => do
   match macroRes with
   | some (name, _) => logInfo s!"Next step is a macro: {name.toString}"
   | none =>
-    let kind := c.getKind
+    let kind := c.raw.getKind
     let elabs := commandElabAttribute.getEntries (←getEnv) kind
     match elabs with
     | [] => logInfo s!"There is no elaborators for your syntax, looks like its bad :("
@@ -322,7 +322,7 @@ def myanonImpl : TermElab := fun stx typ? => do
     throwError "expected type must be known"
   let Expr.const base .. := typ.getAppFn | throwError s!"type is not of the expected form: {typ}"
   let [ctor] ← getCtors base | throwError "type doesn't have exactly one constructor"
-  let args := stx[1].getSepArgs
+  let args := TSyntaxArray.mk stx[1].getSepArgs
   let stx ← `($(mkIdent ctor) $args*) -- syntax quotations
   elabTerm stx typ -- call term elaboration recursively
 

--- a/lean/main/intro.lean
+++ b/lean/main/intro.lean
@@ -91,7 +91,7 @@ Let's see the code:
 import Lean
 
 elab "#assertType " termStx:term " : " typeStx:term : command =>
-  open Lean.Elab Command Term in
+  open Lean Lean.Elab Command Term in
   liftTermElabM `assertTypeCmd
     try
       let tp ← elabType typeStx
@@ -232,7 +232,7 @@ They behave a bit differently though, as we can see below:
 
 elab "traces" : tactic => do
   let array := List.replicate 2 (List.range 3)
-  Lean.Elab.logInfo m!"logInfo: {array}"
+  Lean.logInfo m!"logInfo: {array}"
   dbg_trace f!"dbg_trace: {array}"
 
 example : True := by -- `example` is underlined in blue, outputting:

--- a/lean/main/macros.lean
+++ b/lean/main/macros.lean
@@ -125,19 +125,51 @@ it will be essential to all non trivial things that are syntax related.
 First things first we call the `` `() `` syntax a `Syntax` quotation.
 When we plug variables into a syntax quotation like this: `` `($x) ``
 we call the `$x` part an anti-quotation. When we insert `x` like this
-it is of course required that `x` is of type `Syntax`. If we use this
-in pattern matching it will give us a variable `x` of type `Syntax`
-in the match arm. If we want to insert a literal `$x` into the `Syntax`
-for some reason, for example macro creating macros, we can escape
-the anti quotation using: `` `($$x) ``.
+it is required that `x` is of type `TSyntax x` where `x` is some `Name`
+of a syntax category. The Lean compiler is actually smart enough to figure
+the syntax categories that are allowed in this place out. Hence you might
+sometimes see errors of the form:
+```
+application type mismatch
+  x.raw
+argument
+  x
+has type
+  TSyntax `a : Type
+but is expected to have type
+  TSyntax `b : Type
+```
+If you are sure that your thing from the `a` syntax category can be
+used as a `b` here you can declare a coercion of the form:
+-/
+
+instance : Coe (TSyntax `a) (TSyntax `b) where
+  coe s := ⟨s.raw⟩
+
+/-!
+Which will allow Lean to perform the type cast automatically. If you
+notice that your `a` can not be used in place of the `b` here congrats,
+you just discovered a bug in your `Syntax` function. Similar to the Lean
+compiler you could can also declare functions that are specific to certain
+`TSynax` variants. For example as we have seen in the syntax chapter
+there exists the function:
+-/
+#check TSyntax.getNat -- TSyntax.getNat : TSyntax numLitKind → Nat
+/-!
+Which is guaranteed to not panic because we know that the `Syntax` that
+the function is receiving is a numeric literal and can thus naturally
+be converted to a `Nat`.
+
+If we use the antiquotation syntax in pattern matching it will, as discussed
+in the syntax chapter, give us a a variable `x` of type `` TSyntax y `` where
+`y` is the `Name` of the syntax category that fits in the spot where we pattern matched.
+If we wish to insert a literal `$x` into the `Syntax` for some reason,
+for example macro creating macros, we can escape the anti quotation using: `` `($$x) ``.
 
 If we want to specify the syntax kind we wish `x` to be interpreted as
 we can make this explicit using: `` `($x:term) `` where `term` can be
 replaced with any other valid syntax category (e.g. `command`) or parser
-(e.g. `ident`). While this feature is most useful in pattern matching it
-can also be useful to give hints to Lean as to how to work with a certain
-piece of `Syntax` when creating new ones using a `Syntax` quotation.
-(TODO: showcase bugs where this is necessary).
+(e.g. `ident`). 
 
 So far this is only a more formal explanation of the intuitive things
 we've already seen in the syntax chapter and up to now in this chapter,
@@ -149,17 +181,17 @@ format strings: `` `($(mkIdent `c)) `` is the same as: `` let x := mkIdent `c; `
 
 Furthermore there are sometimes situations in which we are not working
 with basic `Syntax` but `Syntax` wrapped in more complex datastructures,
-most notably `Array Syntax` or `SepArray c`. Where `SepArray c`, is a
+most notably `Array (TSyntax c)` or `TSepArray c s`. Where `TSepArray c s`, is a
 `Syntax` specific type, it is what we get if we pattern match on some
-`Syntax` that users a separator `c`, for example if we match using:
-`$xs,*`, `xs` will have type `SepArray ","`,. With the special
-case of matching on no specific separator (i.e. whitespace): `$xs*`
-in which we will receive an `Array Syntax`.
+`Syntax` that users a separator `s` to separate things from the category `c`.
+For example if we match using: `$xs,*`, `xs` will have type `TSepArray c ","`,.
+With the special case of matching on no specific separator (i.e. whitespace):
+`$xs*` in which we will receive an `Array (TSyntax c)`.
 
-If we are dealing with `xs : Array Syntax` and want to insert it into
+If we are dealing with `xs : Array (TSyntax c)` and want to insert it into
 a quotation we have two main ways to achieve this:
 1. Insert it using a separator, most commonly `,`: `` `($xs,*) ``.
-  This is also the way to insert a `SepArray ",""`
+  This is also the way to insert a `TSepArray c ",""`
 2. Insert it point blank without a separator (TODO): `` `() ``
 
 For example:

--- a/lean/main/macros.lean
+++ b/lean/main/macros.lean
@@ -184,7 +184,7 @@ say our own `let` (in real projects this would most likely be a `let`
 in some functional language we are writing a theory about):
 -/
 
-syntax "mylet " term (" : " term)? " := " term " in " term : term
+syntax "mylet " ident (" : " term)? " := " term " in " term : term
 
 /-!
 There is this optional `(" : " term)?` argument involved which can let

--- a/lean/main/syntax.lean
+++ b/lean/main/syntax.lean
@@ -407,7 +407,7 @@ constant folding:
 -/
 
 def isLitAdd : Syntax → Option Nat
-  | `(Nat.add $x:num $y:num) => some (x.toNat + y.toNat)
+  | `(Nat.add $x:num $y:num) => some (x.getNat + y.getNat)
   | _ => none
 
 #eval isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"]) -- some 2
@@ -437,7 +437,7 @@ syntax arith "+" arith : arith
 syntax "(" arith ")" : arith
 
 partial def denoteArith : Syntax → Nat
-  | `(arith| $x:num) => x.toNat
+  | `(arith| $x:num) => x.getNat
   | `(arith| $x:arith + $y:arith) => denoteArith x + denoteArith y
   | `(arith| $x:arith - $y:arith) => denoteArith x - denoteArith y
   | `(arith| ($x:arith)) => denoteArith x
@@ -529,9 +529,9 @@ def setOf {α : Type} (p : α → Prop) : Set α := p
 Equipped with this function, we can now attempt to intuitively define a
 basic version of our notation:
 -/
-notation "{" x "|" p "}" => setOf (fun x => p)
+notation "{ " x " | " p " }" => setOf (fun x => p)
 
-#check { (x : Nat) | x ≤ 1 } -- setOf fun x => x ≤ 1 : Set Nat
+#check { (x : Nat) | x ≤ 1 } -- { x | x ≤ 1 } : Set Nat
 
 example : 1 ∈ { (y : Nat) | y ≤ 1 } := by simp[Membership.mem, Set.mem, setOf]
 example : 2 ∈ { (y : Nat) | y ≤ 3 ∧ 1 ≤ y } := by simp[Membership.mem, Set.mem, setOf]

--- a/lean/main/syntax.lean
+++ b/lean/main/syntax.lean
@@ -399,14 +399,22 @@ def isAdd : Syntax → Option (Syntax × Syntax)
 #eval isAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo]) -- none
 
 /-!
-Note that `x` and `y` in this example are of type `Syntax`, not `Nat`. This is simply
-because we are still at the `Syntax` level: the concept of a type doesn't quite
-exist yet. What we can however do is limit the parsers/categories we want to match on,
-for example if we only want to match on number literals in order to implement some
-constant folding:
+### Typed Syntax
+Note that `x` and `y` in this example are of type `` TSyntax `term ``, not `Syntax`.
+Even though we are pattern matching on `Syntax` which, as we can see in the constructors,
+is purely composed of types that are not `TSyntax`, so what is going on?
+Basically the `` `() `` Syntax is smart enough to figure out the most general
+syntax category the syntax we are matching might be coming from (in this case `term`).
+It will then use the typed syntax type `TSyntax` which is parameterized
+by the `Name` of the syntax category it came from. This is not only more
+convenient for the programmer to see what is going on, it also has other
+benefits. For Example if we limit the syntax category to just `num`
+in the next example Lean will allow us to call `getNat` on the resulting
+`` TSyntax `num `` directly without pattern matching or the option to panic:
 -/
 
-def isLitAdd : Syntax → Option Nat
+-- Now we are also explicitly marking the function to operate on term syntax
+def isLitAdd : TSyntax `term → Option Nat
   | `(Nat.add $x:num $y:num) => some (x.getNat + y.getNat)
   | _ => none
 
@@ -414,9 +422,9 @@ def isLitAdd : Syntax → Option Nat
 #eval isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"]) -- none
 
 /-!
-As you can see in the code, even though we explicitly matched on the `num`
-parser we still have to explicitly convert `x` and `y` to `Nat` because
-again, we are on `Syntax` level, types do not exist.
+If you want to access the `Syntax` behind a `TSyntax` you can do this using
+`TSyntax.raw` although the coercion machinery should just work most of the time.
+We will see some further benefits of the `TSyntax` system in the macro chapter.
 
 One last important note about the matching on syntax: In this basic
 form it only works on syntax from the `term` category. If you want to use
@@ -436,7 +444,7 @@ syntax arith "-" arith : arith
 syntax arith "+" arith : arith
 syntax "(" arith ")" : arith
 
-partial def denoteArith : Syntax → Nat
+partial def denoteArith : TSyntax `arith → Nat
   | `(arith| $x:num) => x.getNat
   | `(arith| $x:arith + $y:arith) => denoteArith x + denoteArith y
   | `(arith| $x:arith - $y:arith) => denoteArith x - denoteArith y

--- a/md/extra/options.md
+++ b/md/extra/options.md
@@ -61,7 +61,7 @@ To show this, let's write a command that prints the value of `pp.explicit`.
 elab "#getPPExplicit" : command => do
   let opts ← getOptions
   -- defValue = default value
-  Elab.logInfo s!"pp.explicit : {opts.get pp.explicit.name pp.explicit.defValue}"
+  logInfo s!"pp.explicit : {opts.get pp.explicit.name pp.explicit.defValue}"
 
 #getPPExplicit -- pp.explicit : false
 

--- a/md/extra/pretty-printing.md
+++ b/md/extra/pretty-printing.md
@@ -162,6 +162,12 @@ macro_rules
   | `([Lang| $x:ident]) => `(LangExpr.ident $(Lean.quote (toString x.getId)))
   | `([Lang| let $x:ident := $v:lang in $b:lang]) => `(LangExpr.letE $(Lean.quote (toString x.getId)) [Lang| $v] [Lang| $b])
 
+instance : Coe NumLit (TSyntax `lang) where
+  coe s := ⟨s.raw⟩
+
+instance : Coe Ident (TSyntax `lang) where
+  coe s := ⟨s.raw⟩
+
 -- LangExpr.letE "foo" (LangExpr.numConst 12)
 --   (LangExpr.letE "bar" (LangExpr.ident "foo") (LangExpr.ident "foo")) : LangExpr
 #check [Lang|
@@ -183,21 +189,17 @@ def unexpandNumConst : Unexpander
 @[appUnexpander LangExpr.ident]
 def unexpandIdent : Unexpander
   | `(LangExpr.ident $x:str) =>
-    if let some str := x.isStrLit? then
-      let name := mkIdent $ Name.mkSimple str
-      `([Lang| $name])
-    else
-      throw ()
+    let str := x.getString
+    let name := mkIdent $ Name.mkSimple str
+    `([Lang| $name])
   | _ => throw ()
 
 @[appUnexpander LangExpr.letE]
 def unexpandLet : Unexpander
   | `(LangExpr.letE $x:str [Lang| $v:lang] [Lang| $b:lang]) =>
-    if let some str := x.isStrLit? then
-      let name := mkIdent $ Name.mkSimple str
-      `([Lang| let $name := $v in $b])
-    else
-      throw ()
+    let str := x.getString
+    let name := mkIdent $ Name.mkSimple str
+    `([Lang| let $name := $v in $b])
   | _ => throw ()
 
 -- [Lang| let foo := 12 in foo] : LangExpr

--- a/md/main/dsls.md
+++ b/md/main/dsls.md
@@ -82,7 +82,7 @@ syntax "false"   : imp_lit
 def elabIMPLit : Syntax → MetaM Expr
   -- `mkAppM` creates an `Expr.app`, given the function `Name` and the args
   -- `mkNatLit` creates an `Expr` from a `Nat`
-  | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.toNat]
+  | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.getNat]
   -- `mkConst` creates an `Expr.const` given the constant `Name`
   | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.true]
   | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.false]

--- a/md/main/elaboration.md
+++ b/md/main/elaboration.md
@@ -158,7 +158,7 @@ elab "#findCElab " c:command : command => do
   match macroRes with
   | some (name, _) => logInfo s!"Next step is a macro: {name.toString}"
   | none =>
-    let kind := c.getKind
+    let kind := c.raw.getKind
     let elabs := commandElabAttribute.getEntries (←getEnv) kind
     match elabs with
     | [] => logInfo s!"There is no elaborators for your syntax, looks like its bad :("
@@ -323,7 +323,7 @@ def myanonImpl : TermElab := fun stx typ? => do
     throwError "expected type must be known"
   let Expr.const base .. := typ.getAppFn | throwError s!"type is not of the expected form: {typ}"
   let [ctor] ← getCtors base | throwError "type doesn't have exactly one constructor"
-  let args := stx[1].getSepArgs
+  let args := TSyntaxArray.mk stx[1].getSepArgs
   let stx ← `($(mkIdent ctor) $args*) -- syntax quotations
   elabTerm stx typ -- call term elaboration recursively
 

--- a/md/main/intro.md
+++ b/md/main/intro.md
@@ -90,7 +90,7 @@ Let's see the code:
 import Lean
 
 elab "#assertType " termStx:term " : " typeStx:term : command =>
-  open Lean.Elab Command Term in
+  open Lean Lean.Elab Command Term in
   liftTermElabM `assertTypeCmd
     try
       let tp ← elabType typeStx
@@ -234,7 +234,7 @@ They behave a bit differently though, as we can see below:
 ```lean
 elab "traces" : tactic => do
   let array := List.replicate 2 (List.range 3)
-  Lean.Elab.logInfo m!"logInfo: {array}"
+  Lean.logInfo m!"logInfo: {array}"
   dbg_trace f!"dbg_trace: {array}"
 
 example : True := by -- `example` is underlined in blue, outputting:


### PR DESCRIPTION
The most notable change here is the explanation and usage of types syntax (`TSyntax`) there are two things left to do here:
- I did only explain the easy (although almost exclusive) case where `TSyntax` is only parameterized by one syntax category, in theory it can be parameterized by an entire list of syntax categories but that is rather rare
- I did not look through every bit of code from the other chapters to see whether we could add `TSyntax` there