### PR TITLE
fix: 't <|> u' -> 'first | t | u'

### DIFF
--- a/lean/main/metam.lean
+++ b/lean/main/metam.lean
@@ -1110,7 +1110,7 @@ example (h : α → β) (a : α) : β := by
 Many tactics naturally require backtracking: the ability to go back to a
 previous state, as if the tactic had never been executed. A few examples:
 
-- `t <|> u` first executes `t`. If `t` fails, it backtracks and executes `u`.
+- `first | t | u` first executes `t`. If `t` fails, it backtracks and executes `u`.
 - `try t` executes `t`. If `t` fails, it backtracks to the initial state,
   erasing any changes made by `t`.
 - `trivial` attempts to solve the goal using a number of simple tactics


### PR DESCRIPTION
`t <|> u` does not exist in Lean 4 at a tactic level. (It does exist as a monadic combinator.)

See https://leanprover-community.github.io/mathlib4_docs/Init/Tactics.html#Lean.Parser.Tactic.first

https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/tactic1.20.3C.7C.3E.20tactic2/near/289847287