### PR TITLE
Clean up some deprecations etc.

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,9 +6,10 @@ package «lean4-metaprogramming-book» {
   isLeanOnly := true
 }
 
-@[defaultTarget]
+@[default_target]
 lean_lib «lean4-metaprogramming-book» {
   roots := #[`cover, `extra, `main]
+  globs := #[Glob.one `cover, Glob.submodules `extra, Glob.submodules `main]
 }
 
 def runCmd (cmd : String) (args : Array String) : ScriptM Bool := do

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-10-10
+leanprover/lean4:nightly-2022-10-24

--- a/lean/extra/pretty-printing.lean
+++ b/lean/extra/pretty-printing.lean
@@ -103,7 +103,7 @@ Can you extend `delabFooFinal` to also account for non full applications?
 
 ## Unexpanders
 While delaborators are obviously quite powerful it is quite often not necessary
-to use them. If you look in the Lean compiler for `@[delab` or rather `@[builtinDelab`
+to use them. If you look in the Lean compiler for `@[delab` or rather `@[builtin_delab`
 (a special version of the `delab` attribute for compiler use, we don't care about it),
 you will see there are quite few occurences of it. This is because the majority
 of pretty printing is in fact done by so called unexpanders. Unlike delaborators
@@ -117,14 +117,14 @@ weaker than `DelabM` but it still has:
   is the only valid one
 
 Unexpanders are always specific to applications of one constant. They are registered
-using the `appUnexpand` attribute, followed by the name of said constant. The unexpander
+using the `app_unexpander` attribute, followed by the name of said constant. The unexpander
 is passed the entire application of the constant after the `Expr` has been delaborated,
 without implicit arguments. Let's see this in action:
 -/
 
 def myid {α : Type} (x : α) := x
 
-@[appUnexpander myid]
+@[app_unexpander myid]
 def unexpMyId : Unexpander
   -- hygiene disabled so we can actually return `id` without macro scopes etc.
   | `(myid $arg) => set_option hygiene false in `(id $arg)
@@ -181,12 +181,12 @@ As you can see, the pretty printing output right now is rather ugly to look at.
 We can do better with an unexpander:
 -/
 
-@[appUnexpander LangExpr.numConst]
+@[app_unexpander LangExpr.numConst]
 def unexpandNumConst : Unexpander
   | `(LangExpr.numConst $x:num) => `([Lang| $x])
   | _ => throw ()
 
-@[appUnexpander LangExpr.ident]
+@[app_unexpander LangExpr.ident]
 def unexpandIdent : Unexpander
   | `(LangExpr.ident $x:str) =>
     let str := x.getString
@@ -194,7 +194,7 @@ def unexpandIdent : Unexpander
     `([Lang| $name])
   | _ => throw ()
 
-@[appUnexpander LangExpr.letE]
+@[app_unexpander LangExpr.letE]
 def unexpandLet : Unexpander
   | `(LangExpr.letE $x:str [Lang| $v:lang] [Lang| $b:lang]) =>
     let str := x.getString

--- a/lean/main/cheat-sheet.lean
+++ b/lean/main/cheat-sheet.lean
@@ -6,11 +6,11 @@
 * Extract the goal: `Lean.Elab.Tactic.getMainGoal`
 
   Use as `let goal ← Lean.Elab.Tactic.getMainGoal`
-* Extract the declaration out of a metavariable: `Lean.Meta.getMVarDecl mvar`
-  when `mvar : Lean.MVarId` is in context.
-  For instance, `mvar` could be the goal extracted using `getMainGoal`
-* Extract the type of a metavariable: `Lean.MetavarDecl.type mvdecl`
-  when `mvdecl : Lean.MetavarDecl` is in context.
+* Extract the declaration out of a metavariable: `mvarId.getDecl`
+  when `mvarId : Lean.MVarId` is in context.
+  For instance, `mvarId` could be the goal extracted using `getMainGoal`
+* Extract the type of a metavariable: `mvarId.getType`
+  when `mvarId : Lean.MVarId` is in context.
 * Extract the type of the main goal: `Lean.Elab.Tactic.getMainTarget`
 
   Use as `let goal_type ← Lean.Elab.Tactic.getMainTarget`
@@ -18,8 +18,7 @@
   Achieves the same as 
 ```lean
 let goal ← Lean.Elab.Tactic.getMainGoal
-let goal_decl ← Lean.Meta.getMVarDecl goal
-let goal_type := goal_decl.type
+let goal_type ← goal.getType
 ```
 * Extract local context: `Lean.MonadLCtx.getLCtx`
 
@@ -38,10 +37,8 @@ let goal_type := goal_decl.type
   Use as `ldecl.toExpr`, when `ldecl : Lean.LocalDecl` is in context
   
   For instance, `ldecl` could be `let ldecl ← Lean.MonadLCtx.getLCtx`
-* Check whether two expressions are definitionally equal: `Lean.Meta.isExprDefEq ex1 ex2`
+* Check whether two expressions are definitionally equal: `Lean.Meta.isDefEq ex1 ex2`
   when `ex1 ex2 : Lean.Expr` are in context. Returns a `Lean.MetaM Bool`
-  
-  `isDefEq ex1 ex2` appears to be a synonym
 * Close a goal: `Lean.Elab.Tactic.closeMainGoal expr`
   when `expr : Lean.Expr` is in context
 

--- a/lean/main/dsls.lean
+++ b/lean/main/dsls.lean
@@ -77,9 +77,8 @@ def elabIMPLit : Syntax → MetaM Expr
   -- `mkAppM` creates an `Expr.app`, given the function `Name` and the args
   -- `mkNatLit` creates an `Expr` from a `Nat`
   | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.getNat]
-  -- `mkConst` creates an `Expr.const` given the constant `Name`
-  | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.true]
-  | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.false]
+  | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[.const ``Bool.true []]
+  | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[.const ``Bool.false []]
   | _ => throwUnsupportedSyntax
 
 elab "test_elabIMPLit " l:imp_lit : term => elabIMPLit l
@@ -102,7 +101,7 @@ declare_syntax_cat imp_unop
 syntax "not"     : imp_unop
 
 def elabIMPUnOp : Syntax → MetaM Expr
-  | `(imp_unop| not) => return mkConst ``IMPUnOp.not
+  | `(imp_unop| not) => return .const ``IMPUnOp.not []
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat imp_binop
@@ -111,9 +110,9 @@ syntax "and"     : imp_binop
 syntax "<"       : imp_binop
 
 def elabIMPBinOp : Syntax → MetaM Expr
-  | `(imp_binop| +)   => return mkConst ``IMPBinOp.add
-  | `(imp_binop| and) => return mkConst ``IMPBinOp.and
-  | `(imp_binop| <)   => return mkConst ``IMPBinOp.less
+  | `(imp_binop| +)   => return .const ``IMPBinOp.add []
+  | `(imp_binop| and) => return .const ``IMPBinOp.and []
+  | `(imp_binop| <)   => return .const ``IMPBinOp.less []
   | _ => throwUnsupportedSyntax
 
 /-Now we define the syntax for expressions: -/
@@ -183,7 +182,7 @@ syntax "if" imp_expr "then" imp_program "else" imp_program "fi" : imp_program
 syntax "while" imp_expr "do" imp_program "od" : imp_program
 
 partial def elabIMPProgram : Syntax → MetaM Expr
-  | `(imp_program| skip) => return mkConst ``IMPProgram.Skip
+  | `(imp_program| skip) => return .const ``IMPProgram.Skip []
   | `(imp_program| $i:ident := $e:imp_expr) => do
     let i : Expr := mkStrLit i.getId.toString
     let e ← elabIMPExpr e

--- a/lean/main/elaboration.lean
+++ b/lean/main/elaboration.lean
@@ -280,13 +280,13 @@ def mytermValues := [1, 2]
 
 @[term_elab myterm1]
 def myTerm1Impl : TermElab := fun stx type? =>
-  mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 0] -- `MetaM` code
+  mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 0] -- `MetaM` code
 
 #eval myterm 1 -- 1
 
 -- Also works with `elab`
 elab "myterm 2" : term => do
-  mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 1] -- `MetaM` code
+  mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 1] -- `MetaM` code
 
 #eval myterm 2 -- 2
 

--- a/lean/main/elaboration.lean
+++ b/lean/main/elaboration.lean
@@ -62,7 +62,7 @@ look at how the elaboration process actually works:
    the resulting `Syntax` is recursively elaborated as a command again.
 2. If no macro can be applied, we search for all `CommandElab`s that have been
    registered for the `SyntaxKind` of the `Syntax` we are elaborating,
-   using the `commandElabAttribute`.
+   using the `command_elab` attribute.
 3. All of these `CommandElab` are then tried in order until one of them does not throw an
    `unsupportedSyntaxException`, Lean's way of indicating that the elaborator
    "feels responsible"
@@ -78,7 +78,8 @@ Now that we know both what a `CommandElab` is and how they are used, we can
 start looking into writing our own. The steps for this, as we learned above, are:
 1. Declaring the syntax
 2. Declaring the elaborator
-3. Registering the elaborator as responsible for the syntax via `commandElabAttribute`
+3. Registering the elaborator as responsible for the syntax via the `command_elab`
+   attribute.
 
 Let's see how this is done:
 -/
@@ -89,7 +90,7 @@ open Lean Elab Command Term Meta
 
 syntax (name := mycommand1) "#mycommand1" : command -- declare the syntax
 
-@[commandElab mycommand1]
+@[command_elab mycommand1]
 def mycommand1Impl : CommandElab := fun stx => do -- declare and register the elaborator
   logInfo "Hello World"
 
@@ -109,7 +110,7 @@ Note that, due to the fact that command elaboration supports multiple
 registered elaborators for the same syntax, we can in fact overload
 syntax, if we want to.
 -/
-@[commandElab mycommand1]
+@[command_elab mycommand1]
 def myNewImpl : CommandElab := fun stx => do
   logInfo "new!"
 
@@ -132,7 +133,7 @@ elab "#check" "mycheck" : command => do
 /-
 This is actually extending the original `#check`
 -/
-@[commandElab Lean.Parser.Command.check] def mySpecialCheck : CommandElab := fun stx => do
+@[command_elab Lean.Parser.Command.check] def mySpecialCheck : CommandElab := fun stx => do
   if let some str := stx[1].isStrLit? then
     logInfo s!"Specially elaborated string literal!: {str} : String"
   else
@@ -213,7 +214,7 @@ The second one is very specific to the term elaboration loop.
 ### Term elaboration
 The basic idea of term elaboration is the same as command elaboration:
 expand macros and recurse or run term elaborators that have been registered
-for the `Syntax` via the `termElabAttribute` (they might in turn run term elaboration)
+for the `Syntax` via the `term_elab` attribute (they might in turn run term elaboration)
 until we are done. There is, however, one special action that a term elaborator
 can do during its execution.
 
@@ -277,7 +278,7 @@ syntax (name := myterm1) "myterm 1" : term
 
 def mytermValues := [1, 2]
 
-@[termElab myterm1]
+@[term_elab myterm1]
 def myTerm1Impl : TermElab := fun stx type? =>
   mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 0] -- `MetaM` code
 
@@ -306,7 +307,7 @@ def getCtors (typ : Name) : MetaM (List Name) := do
     pure val.ctors
   | _ => pure []
 
-@[termElab myanon]
+@[term_elab myanon]
 def myanonImpl : TermElab := fun stx typ? => do
   -- Attempt to postpone execution if the type is not known or is a metavariable.
   -- Metavariables are used by things like the function elaborator to fill

--- a/lean/main/expressions.lean
+++ b/lean/main/expressions.lean
@@ -41,8 +41,8 @@ end Playground
 
 - `bvar` is a __bound variable__. For example, the `x` in `fun x => x + 2` or
   `∑ x, x²`. This is any occurrence of a variable in an expression where there
-  is a binder above it. Why is the argument a `Nat`? This is called a de-Bruijn
-  index and will be explained ahead. You can figure out the type of a bound
+  is a binder above it. Why is the argument a `Nat`? This is called a de Bruijn
+  index and will be explained later. You can figure out the type of a bound
   variable by looking at its binder, since the binder always has the type
   information for it.
 - `fvar` is a __free variable__. These are variables which are not bound by a
@@ -77,14 +77,14 @@ end Playground
   `proj Prod 0 p`. This is for efficiency reasons ([todo] find link to docstring
   explaining this).
 
-## de-Bruijn Indexes
+## De Bruijn Indexes
 
 Consider the following lambda expression `(λ f x => f x x) (λ x y => x + y) 5`,
 we have to be very careful when we reduce this, because we get a clash in the
 variable `x`.
 
 To avoid variable name-clash carnage, `Expr`s use a nifty trick called
-__de-Bruijn indexes__. In de-Bruijn indexing, each variable bound by a `lam` or
+__de Bruijn indexes__. In de Bruijn indexing, each variable bound by a `lam` or
 a `forallE` is converted into a number `#n`. The number says how many binders up
 the `Expr` tree we should look to find the binder which binds this variable.
 So our above example would become (putting wildcards `_` in the type arguments

--- a/lean/main/expressions.lean
+++ b/lean/main/expressions.lean
@@ -62,16 +62,14 @@ end Playground
   is called the __body__. Note that you have to give the type of the variable
   you are binding.
 - `forallE n t b` is a dependent arrow expression (`($n : $t) → $b`). This is
-  also sometimes called a Π-type or Π-expression. Note that the non-dependent
-  arrow `α → β` is a special case of `(a : α) → β` where `β` doesn't depend on
-  `a`. The `E` on the end of `forallE` is to distinguish it from the `forall`
-  keyword.
+  also sometimes called a Π-type or Π-expression and is often written `∀ $n :
+  $t, $b`. Note that the non-dependent arrow `α → β` is a special case of `(a :
+  α) → β` where `β` doesn't depend on `a`. The `E` on the end of `forallE` is to
+  distinguish it from the `forall` keyword.
 - `letE n t v b` is a __let binder__ (`let ($n : $t) := $v in $b`).
 - `lit` is a __literal__, this is a number or string literal like `4` or
-  `"hello world"`. These are not strictly necessary for the kernel, but they are
-  kept mainly for convenience. (Ie in Lean 3, there were a load of tricks needed
-  to store `11234 : Nat` as something more efficient than
-  `succ $ succ $ succ ... $ succ zero`)
+  `"hello world"`. Literals help with performance: we don't want to represent
+  the expression `(10000 : Nat)` as `Nat.succ $ ... $ Nat.succ Nat.zero`.
 - `mdata` is just a way of storing extra information on expressions that might
   be useful, without changing the nature of the expression.
 - `proj` is for projection. Suppose you have a structure such as `p : α × β`,
@@ -81,7 +79,7 @@ end Playground
 
 ## de-Bruijn Indexes
 
-Consider the following lambda expression ` (λ f x => f x x) (λ x y => x + y) 5`,
+Consider the following lambda expression `(λ f x => f x x) (λ x y => x + y) 5`,
 we have to be very careful when we reduce this, because we get a clash in the
 variable `x`.
 
@@ -103,70 +101,73 @@ __abstraction__.
 
 ## Constructing Expressions
 
-The simplest expressions we can construct are constants. We use `mkConst`
-with argument a name. Below are two examples of this, both giving an expression
-for the natural number `0`. 
+The simplest expressions we can construct are constants. We use the `const`
+constructor and give it a name and a list of universe levels.
 
-The second form (with double backticks) is better, as it resolves the name to a
-global name, checking, in the process that it is valid. -/
+We also show a second form where we write the name with double backticks. This
+checks that the name in fact refers to a defined constant, which is useful to
+avoid typos. -/
 
 open Lean
 
-def z' := mkConst `Nat.zero
+def z' := Expr.const `Nat.zero []
 #eval z' -- Lean.Expr.const `Nat.zero []
 
-def z := mkConst ``Nat.zero
+def z := Expr.const ``Nat.zero []
 #eval z -- Lean.Expr.const `Nat.zero []
 
-/- To illustrate the difference, here are two further examples. The first
-definition is unsafe as it is not valid without `open Nat` in the context. On
-the other hand, the second resolves correctly. -/
+/- The double-backtick variant also resolves the given name, making it
+fully-qualified. To illustrate this mechanism, here are two further examples.
+The first expression, `z₁`, is unsafe: if we use it in a context where the `Nat`
+namespace is not open, Lean will complain that there is no constant called
+`zero` in the environment. In contrast, the second expression, `z₂`, contains
+the fully-qualified name `Nat.zero` and does not have this problem. -/
 
 open Nat
 
-def z₁ := mkConst `zero
+def z₁ := Expr.const `zero []
 #eval z₁ -- Lean.Expr.const `zero []
 
-def z₂ := mkConst ``zero
+def z₂ := Expr.const ``zero []
 #eval z₂ -- Lean.Expr.const `Nat.zero []
 
 /- The next class of expressions we consider are function applications. These
-can be built using `mkApp` with the first argument being an expression for the
-function and the second being an expression for the argument.
+can be built using the `app` constructor, with the first argument being an
+expression for the function and the second being an expression for the argument.
 
 Here are two examples. The first is simply a constant applied to another. The
 second is a recursive definition giving an expression as a function of a natural
-number.
--/
+number. -/
 
-def one := mkApp (mkConst ``Nat.succ) z
+def one := Expr.app (.const ``Nat.succ []) z
 #eval one
 -- Lean.Expr.app (Lean.Expr.const `Nat.succ []) (Lean.Expr.const `Nat.zero [])
 
 def natExpr: Nat → Expr 
 | 0     => z
-| n + 1 => mkApp (mkConst ``Nat.succ) (natExpr n)
+| n + 1 => .app (.const ``Nat.succ []) (natExpr n)
 
-/- Next we use the variant `mkAppN` which allows application with multiple
+/-  Next we use the variant `mkAppN` which allows application with multiple
 arguments. -/
 
 def sumExpr : Nat → Nat → Expr 
-| n, m => mkAppN (mkConst ``Nat.add) #[natExpr n, natExpr m]
+| n, m => mkAppN (.const ``Nat.add []) #[natExpr n, natExpr m]
 
 /- As you may have noticed, we didn't show `#eval` outputs for the two last
 functions. That's because the resulting expressions can grow so large that it's
 hard to make sense of them.
 
-We next consider the helper `mkLambda` to construct a simple function which
-takes any natural number `x` and returns `Nat.zero`. The argument
-`BinderInfo.default` for the constructor says that `x` is explicit. -/
+We next use the constructor `lam` to construct a simple function which takes any
+natural number `x` and returns `Nat.zero`. The argument `BinderInfo.default`
+says that `x` is an explicit argument (rather than an implicit or typeclass
+argument). -/
 
 def constZero : Expr := 
-  mkLambda `x BinderInfo.default (mkConst ``Nat) (mkConst ``Nat.zero)
+  .lam `x (.const ``Nat []) (.const ``Nat.zero []) BinderInfo.default
 
 #eval constZero
 -- Lean.Expr.lam `x (Lean.Expr.const `Nat []) (Lean.Expr.const `Nat.zero [])
 --   (Lean.BinderInfo.default)
 
-/- In the next chapter we shall explore some functions that compute in the
-`MetaM` monad, opening room for more powerful tricks involving expressions. -/
+/- In the next chapter we explore the `MetaM` monad, which, among many other
+things, allows us to conveniently construct and destruct larger expressions. -/

--- a/lean/main/intro.lean
+++ b/lean/main/intro.lean
@@ -217,10 +217,10 @@ open Lean Meta Elab Tactic Term in
 elab "suppose " n:ident " : " t:term : tactic => do
   let n : Name := n.getId
   let mvarId ← getMainGoal
-  withMVarContext mvarId do
+  mvarId.withContext do
     let t ← elabType t
     let p ← mkFreshExprMVar t MetavarKind.syntheticOpaque n
-    let (_, mvarIdNew) ← intro1P $ ← assert mvarId n t p
+    let (_, mvarIdNew) ← intro1P $ ← mvarId.assert n t p
     replaceMainGoal [p.mvarId!, mvarIdNew]
   evalTactic $ ← `(tactic|rotate_left)
 

--- a/md/extra/pretty-printing.md
+++ b/md/extra/pretty-printing.md
@@ -103,7 +103,7 @@ Can you extend `delabFooFinal` to also account for non full applications?
 
 ## Unexpanders
 While delaborators are obviously quite powerful it is quite often not necessary
-to use them. If you look in the Lean compiler for `@[delab` or rather `@[builtinDelab`
+to use them. If you look in the Lean compiler for `@[delab` or rather `@[builtin_delab`
 (a special version of the `delab` attribute for compiler use, we don't care about it),
 you will see there are quite few occurences of it. This is because the majority
 of pretty printing is in fact done by so called unexpanders. Unlike delaborators
@@ -117,14 +117,14 @@ weaker than `DelabM` but it still has:
   is the only valid one
 
 Unexpanders are always specific to applications of one constant. They are registered
-using the `appUnexpand` attribute, followed by the name of said constant. The unexpander
+using the `app_unexpander` attribute, followed by the name of said constant. The unexpander
 is passed the entire application of the constant after the `Expr` has been delaborated,
 without implicit arguments. Let's see this in action:
 
 ```lean
 def myid {α : Type} (x : α) := x
 
-@[appUnexpander myid]
+@[app_unexpander myid]
 def unexpMyId : Unexpander
   -- hygiene disabled so we can actually return `id` without macro scopes etc.
   | `(myid $arg) => set_option hygiene false in `(id $arg)
@@ -181,12 +181,12 @@ As you can see, the pretty printing output right now is rather ugly to look at.
 We can do better with an unexpander:
 
 ```lean
-@[appUnexpander LangExpr.numConst]
+@[app_unexpander LangExpr.numConst]
 def unexpandNumConst : Unexpander
   | `(LangExpr.numConst $x:num) => `([Lang| $x])
   | _ => throw ()
 
-@[appUnexpander LangExpr.ident]
+@[app_unexpander LangExpr.ident]
 def unexpandIdent : Unexpander
   | `(LangExpr.ident $x:str) =>
     let str := x.getString
@@ -194,7 +194,7 @@ def unexpandIdent : Unexpander
     `([Lang| $name])
   | _ => throw ()
 
-@[appUnexpander LangExpr.letE]
+@[app_unexpander LangExpr.letE]
 def unexpandLet : Unexpander
   | `(LangExpr.letE $x:str [Lang| $v:lang] [Lang| $b:lang]) =>
     let str := x.getString

--- a/md/main/cheat-sheet.md
+++ b/md/main/cheat-sheet.md
@@ -5,11 +5,11 @@
 * Extract the goal: `Lean.Elab.Tactic.getMainGoal`
 
   Use as `let goal ← Lean.Elab.Tactic.getMainGoal`
-* Extract the declaration out of a metavariable: `Lean.Meta.getMVarDecl mvar`
-  when `mvar : Lean.MVarId` is in context.
-  For instance, `mvar` could be the goal extracted using `getMainGoal`
-* Extract the type of a metavariable: `Lean.MetavarDecl.type mvdecl`
-  when `mvdecl : Lean.MetavarDecl` is in context.
+* Extract the declaration out of a metavariable: `mvarId.getDecl`
+  when `mvarId : Lean.MVarId` is in context.
+  For instance, `mvarId` could be the goal extracted using `getMainGoal`
+* Extract the type of a metavariable: `mvarId.getType`
+  when `mvarId : Lean.MVarId` is in context.
 * Extract the type of the main goal: `Lean.Elab.Tactic.getMainTarget`
 
   Use as `let goal_type ← Lean.Elab.Tactic.getMainTarget`
@@ -17,8 +17,7 @@
   Achieves the same as 
 ```lean
 let goal ← Lean.Elab.Tactic.getMainGoal
-let goal_decl ← Lean.Meta.getMVarDecl goal
-let goal_type := goal_decl.type
+let goal_type ← goal.getType
 ```
 * Extract local context: `Lean.MonadLCtx.getLCtx`
 
@@ -37,10 +36,8 @@ let goal_type := goal_decl.type
   Use as `ldecl.toExpr`, when `ldecl : Lean.LocalDecl` is in context
   
   For instance, `ldecl` could be `let ldecl ← Lean.MonadLCtx.getLCtx`
-* Check whether two expressions are definitionally equal: `Lean.Meta.isExprDefEq ex1 ex2`
+* Check whether two expressions are definitionally equal: `Lean.Meta.isDefEq ex1 ex2`
   when `ex1 ex2 : Lean.Expr` are in context. Returns a `Lean.MetaM Bool`
-  
-  `isDefEq ex1 ex2` appears to be a synonym
 * Close a goal: `Lean.Elab.Tactic.closeMainGoal expr`
   when `expr : Lean.Expr` is in context
 

--- a/md/main/dsls.md
+++ b/md/main/dsls.md
@@ -83,9 +83,8 @@ def elabIMPLit : Syntax → MetaM Expr
   -- `mkAppM` creates an `Expr.app`, given the function `Name` and the args
   -- `mkNatLit` creates an `Expr` from a `Nat`
   | `(imp_lit| $n:num) => mkAppM ``IMPLit.nat  #[mkNatLit n.getNat]
-  -- `mkConst` creates an `Expr.const` given the constant `Name`
-  | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.true]
-  | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[mkConst ``Bool.false]
+  | `(imp_lit| true  ) => mkAppM ``IMPLit.bool #[.const ``Bool.true []]
+  | `(imp_lit| false ) => mkAppM ``IMPLit.bool #[.const ``Bool.false []]
   | _ => throwUnsupportedSyntax
 
 elab "test_elabIMPLit " l:imp_lit : term => elabIMPLit l
@@ -109,7 +108,7 @@ declare_syntax_cat imp_unop
 syntax "not"     : imp_unop
 
 def elabIMPUnOp : Syntax → MetaM Expr
-  | `(imp_unop| not) => return mkConst ``IMPUnOp.not
+  | `(imp_unop| not) => return .const ``IMPUnOp.not []
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat imp_binop
@@ -118,9 +117,9 @@ syntax "and"     : imp_binop
 syntax "<"       : imp_binop
 
 def elabIMPBinOp : Syntax → MetaM Expr
-  | `(imp_binop| +)   => return mkConst ``IMPBinOp.add
-  | `(imp_binop| and) => return mkConst ``IMPBinOp.and
-  | `(imp_binop| <)   => return mkConst ``IMPBinOp.less
+  | `(imp_binop| +)   => return .const ``IMPBinOp.add []
+  | `(imp_binop| and) => return .const ``IMPBinOp.and []
+  | `(imp_binop| <)   => return .const ``IMPBinOp.less []
   | _ => throwUnsupportedSyntax
 ```
 
@@ -192,7 +191,7 @@ syntax "if" imp_expr "then" imp_program "else" imp_program "fi" : imp_program
 syntax "while" imp_expr "do" imp_program "od" : imp_program
 
 partial def elabIMPProgram : Syntax → MetaM Expr
-  | `(imp_program| skip) => return mkConst ``IMPProgram.Skip
+  | `(imp_program| skip) => return .const ``IMPProgram.Skip []
   | `(imp_program| $i:ident := $e:imp_expr) => do
     let i : Expr := mkStrLit i.getId.toString
     let e ← elabIMPExpr e

--- a/md/main/elaboration.md
+++ b/md/main/elaboration.md
@@ -61,7 +61,7 @@ look at how the elaboration process actually works:
    the resulting `Syntax` is recursively elaborated as a command again.
 2. If no macro can be applied, we search for all `CommandElab`s that have been
    registered for the `SyntaxKind` of the `Syntax` we are elaborating,
-   using the `commandElabAttribute`.
+   using the `command_elab` attribute.
 3. All of these `CommandElab` are then tried in order until one of them does not throw an
    `unsupportedSyntaxException`, Lean's way of indicating that the elaborator
    "feels responsible"
@@ -77,7 +77,8 @@ Now that we know both what a `CommandElab` is and how they are used, we can
 start looking into writing our own. The steps for this, as we learned above, are:
 1. Declaring the syntax
 2. Declaring the elaborator
-3. Registering the elaborator as responsible for the syntax via `commandElabAttribute`
+3. Registering the elaborator as responsible for the syntax via the `command_elab`
+   attribute.
 
 Let's see how this is done:
 
@@ -88,7 +89,7 @@ open Lean Elab Command Term Meta
 
 syntax (name := mycommand1) "#mycommand1" : command -- declare the syntax
 
-@[commandElab mycommand1]
+@[command_elab mycommand1]
 def mycommand1Impl : CommandElab := fun stx => do -- declare and register the elaborator
   logInfo "Hello World"
 
@@ -110,7 +111,7 @@ registered elaborators for the same syntax, we can in fact overload
 syntax, if we want to.
 
 ```lean
-@[commandElab mycommand1]
+@[command_elab mycommand1]
 def myNewImpl : CommandElab := fun stx => do
   logInfo "new!"
 
@@ -133,7 +134,7 @@ elab "#check" "mycheck" : command => do
 This is actually extending the original `#check`
 
 ```lean
-@[commandElab Lean.Parser.Command.check] def mySpecialCheck : CommandElab := fun stx => do
+@[command_elab Lean.Parser.Command.check] def mySpecialCheck : CommandElab := fun stx => do
   if let some str := stx[1].isStrLit? then
     logInfo s!"Specially elaborated string literal!: {str} : String"
   else
@@ -213,7 +214,7 @@ The second one is very specific to the term elaboration loop.
 ### Term elaboration
 The basic idea of term elaboration is the same as command elaboration:
 expand macros and recurse or run term elaborators that have been registered
-for the `Syntax` via the `termElabAttribute` (they might in turn run term elaboration)
+for the `Syntax` via the `term_elab` attribute (they might in turn run term elaboration)
 until we are done. There is, however, one special action that a term elaborator
 can do during its execution.
 
@@ -278,7 +279,7 @@ syntax (name := myterm1) "myterm 1" : term
 
 def mytermValues := [1, 2]
 
-@[termElab myterm1]
+@[term_elab myterm1]
 def myTerm1Impl : TermElab := fun stx type? =>
   mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 0] -- `MetaM` code
 
@@ -307,7 +308,7 @@ def getCtors (typ : Name) : MetaM (List Name) := do
     pure val.ctors
   | _ => pure []
 
-@[termElab myanon]
+@[term_elab myanon]
 def myanonImpl : TermElab := fun stx typ? => do
   -- Attempt to postpone execution if the type is not known or is a metavariable.
   -- Metavariables are used by things like the function elaborator to fill

--- a/md/main/elaboration.md
+++ b/md/main/elaboration.md
@@ -281,13 +281,13 @@ def mytermValues := [1, 2]
 
 @[term_elab myterm1]
 def myTerm1Impl : TermElab := fun stx type? =>
-  mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 0] -- `MetaM` code
+  mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 0] -- `MetaM` code
 
 #eval myterm 1 -- 1
 
 -- Also works with `elab`
 elab "myterm 2" : term => do
-  mkAppM ``List.get! #[mkConst ``mytermValues, mkNatLit 1] -- `MetaM` code
+  mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 1] -- `MetaM` code
 
 #eval myterm 2 -- 2
 ```

--- a/md/main/expressions.md
+++ b/md/main/expressions.md
@@ -62,16 +62,14 @@ What is each of these constructors doing?
   is called the __body__. Note that you have to give the type of the variable
   you are binding.
 - `forallE n t b` is a dependent arrow expression (`($n : $t) → $b`). This is
-  also sometimes called a Π-type or Π-expression. Note that the non-dependent
-  arrow `α → β` is a special case of `(a : α) → β` where `β` doesn't depend on
-  `a`. The `E` on the end of `forallE` is to distinguish it from the `forall`
-  keyword.
+  also sometimes called a Π-type or Π-expression and is often written `∀ $n :
+  $t, $b`. Note that the non-dependent arrow `α → β` is a special case of `(a :
+  α) → β` where `β` doesn't depend on `a`. The `E` on the end of `forallE` is to
+  distinguish it from the `forall` keyword.
 - `letE n t v b` is a __let binder__ (`let ($n : $t) := $v in $b`).
 - `lit` is a __literal__, this is a number or string literal like `4` or
-  `"hello world"`. These are not strictly necessary for the kernel, but they are
-  kept mainly for convenience. (Ie in Lean 3, there were a load of tricks needed
-  to store `11234 : Nat` as something more efficient than
-  `succ $ succ $ succ ... $ succ zero`)
+  `"hello world"`. Literals help with performance: we don't want to represent
+  the expression `(10000 : Nat)` as `Nat.succ $ ... $ Nat.succ Nat.zero`.
 - `mdata` is just a way of storing extra information on expressions that might
   be useful, without changing the nature of the expression.
 - `proj` is for projection. Suppose you have a structure such as `p : α × β`,
@@ -81,7 +79,7 @@ What is each of these constructors doing?
 
 ## de-Bruijn Indexes
 
-Consider the following lambda expression ` (λ f x => f x x) (λ x y => x + y) 5`,
+Consider the following lambda expression `(λ f x => f x x) (λ x y => x + y) 5`,
 we have to be very careful when we reduce this, because we get a clash in the
 variable `x`.
 
@@ -103,53 +101,56 @@ __abstraction__.
 
 ## Constructing Expressions
 
-The simplest expressions we can construct are constants. We use `mkConst`
-with argument a name. Below are two examples of this, both giving an expression
-for the natural number `0`. 
+The simplest expressions we can construct are constants. We use the `const`
+constructor and give it a name and a list of universe levels.
 
-The second form (with double backticks) is better, as it resolves the name to a
-global name, checking, in the process that it is valid.
+We also show a second form where we write the name with double backticks. This
+checks that the name in fact refers to a defined constant, which is useful to
+avoid typos.
 
 ```lean
 open Lean
 
-def z' := mkConst `Nat.zero
+def z' := Expr.const `Nat.zero []
 #eval z' -- Lean.Expr.const `Nat.zero []
 
-def z := mkConst ``Nat.zero
+def z := Expr.const ``Nat.zero []
 #eval z -- Lean.Expr.const `Nat.zero []
 ```
 
-To illustrate the difference, here are two further examples. The first
-definition is unsafe as it is not valid without `open Nat` in the context. On
-the other hand, the second resolves correctly.
+The double-backtick variant also resolves the given name, making it
+fully-qualified. To illustrate this mechanism, here are two further examples.
+The first expression, `z₁`, is unsafe: if we use it in a context where the `Nat`
+namespace is not open, Lean will complain that there is no constant called
+`zero` in the environment. In contrast, the second expression, `z₂`, contains
+the fully-qualified name `Nat.zero` and does not have this problem.
 
 ```lean
 open Nat
 
-def z₁ := mkConst `zero
+def z₁ := Expr.const `zero []
 #eval z₁ -- Lean.Expr.const `zero []
 
-def z₂ := mkConst ``zero
+def z₂ := Expr.const ``zero []
 #eval z₂ -- Lean.Expr.const `Nat.zero []
 ```
 
 The next class of expressions we consider are function applications. These
-can be built using `mkApp` with the first argument being an expression for the
-function and the second being an expression for the argument.
+can be built using the `app` constructor, with the first argument being an
+expression for the function and the second being an expression for the argument.
 
 Here are two examples. The first is simply a constant applied to another. The
 second is a recursive definition giving an expression as a function of a natural
 number.
 
 ```lean
-def one := mkApp (mkConst ``Nat.succ) z
+def one := Expr.app (.const ``Nat.succ []) z
 #eval one
 -- Lean.Expr.app (Lean.Expr.const `Nat.succ []) (Lean.Expr.const `Nat.zero [])
 
 def natExpr: Nat → Expr 
 | 0     => z
-| n + 1 => mkApp (mkConst ``Nat.succ) (natExpr n)
+| n + 1 => .app (.const ``Nat.succ []) (natExpr n)
 ```
 
 Next we use the variant `mkAppN` which allows application with multiple
@@ -157,25 +158,26 @@ arguments.
 
 ```lean
 def sumExpr : Nat → Nat → Expr 
-| n, m => mkAppN (mkConst ``Nat.add) #[natExpr n, natExpr m]
+| n, m => mkAppN (.const ``Nat.add []) #[natExpr n, natExpr m]
 ```
 
 As you may have noticed, we didn't show `#eval` outputs for the two last
 functions. That's because the resulting expressions can grow so large that it's
 hard to make sense of them.
 
-We next consider the helper `mkLambda` to construct a simple function which
-takes any natural number `x` and returns `Nat.zero`. The argument
-`BinderInfo.default` for the constructor says that `x` is explicit.
+We next use the constructor `lam` to construct a simple function which takes any
+natural number `x` and returns `Nat.zero`. The argument `BinderInfo.default`
+says that `x` is an explicit argument (rather than an implicit or typeclass
+argument).
 
 ```lean
 def constZero : Expr := 
-  mkLambda `x BinderInfo.default (mkConst ``Nat) (mkConst ``Nat.zero)
+  .lam `x (.const ``Nat []) (.const ``Nat.zero []) BinderInfo.default
 
 #eval constZero
 -- Lean.Expr.lam `x (Lean.Expr.const `Nat []) (Lean.Expr.const `Nat.zero [])
 --   (Lean.BinderInfo.default)
 ```
 
-In the next chapter we shall explore some functions that compute in the
-`MetaM` monad, opening room for more powerful tricks involving expressions.
+In the next chapter we explore the `MetaM` monad, which, among many other
+things, allows us to conveniently construct and destruct larger expressions.

--- a/md/main/expressions.md
+++ b/md/main/expressions.md
@@ -41,8 +41,8 @@ What is each of these constructors doing?
 
 - `bvar` is a __bound variable__. For example, the `x` in `fun x => x + 2` or
   `∑ x, x²`. This is any occurrence of a variable in an expression where there
-  is a binder above it. Why is the argument a `Nat`? This is called a de-Bruijn
-  index and will be explained ahead. You can figure out the type of a bound
+  is a binder above it. Why is the argument a `Nat`? This is called a de Bruijn
+  index and will be explained later. You can figure out the type of a bound
   variable by looking at its binder, since the binder always has the type
   information for it.
 - `fvar` is a __free variable__. These are variables which are not bound by a
@@ -77,14 +77,14 @@ What is each of these constructors doing?
   `proj Prod 0 p`. This is for efficiency reasons ([todo] find link to docstring
   explaining this).
 
-## de-Bruijn Indexes
+## De Bruijn Indexes
 
 Consider the following lambda expression `(λ f x => f x x) (λ x y => x + y) 5`,
 we have to be very careful when we reduce this, because we get a clash in the
 variable `x`.
 
 To avoid variable name-clash carnage, `Expr`s use a nifty trick called
-__de-Bruijn indexes__. In de-Bruijn indexing, each variable bound by a `lam` or
+__de Bruijn indexes__. In de Bruijn indexing, each variable bound by a `lam` or
 a `forallE` is converted into a number `#n`. The number says how many binders up
 the `Expr` tree we should look to find the binder which binds this variable.
 So our above example would become (putting wildcards `_` in the type arguments

--- a/md/main/intro.md
+++ b/md/main/intro.md
@@ -220,10 +220,10 @@ open Lean Meta Elab Tactic Term in
 elab "suppose " n:ident " : " t:term : tactic => do
   let n : Name := n.getId
   let mvarId ← getMainGoal
-  withMVarContext mvarId do
+  mvarId.withContext do
     let t ← elabType t
     let p ← mkFreshExprMVar t MetavarKind.syntheticOpaque n
-    let (_, mvarIdNew) ← intro1P $ ← assert mvarId n t p
+    let (_, mvarIdNew) ← intro1P $ ← mvarId.assert n t p
     replaceMainGoal [p.mvarId!, mvarIdNew]
   evalTactic $ ← `(tactic|rotate_left)
 

--- a/md/main/metam.md
+++ b/md/main/metam.md
@@ -118,7 +118,7 @@ Having created these metavariables, `apply` assigns
 ?m1 := @Eq.trans α (f (f a)) ?b a ?m2 ?m3
 ```
 
-and reports that `?m2`, `?m3` and `b` are now the current goals.
+and reports that `?m2`, `?m3` and `?b` are now the current goals.
 
 At this point the second `apply` tactic takes over. It receives `?m2` as the
 current goal and applies `h` to it. This succeeds and the tactic assigns `?m2 :=
@@ -186,10 +186,10 @@ context, more about which in the next section. If you want to give a different
 local context, use `Lean.Meta.mkFreshExprMVarAt`.
 
 Metavariables are initially unassigned. To assign them, use
-`Lean.Meta.assignExprMVar` with type
+`Lean.MVarId.assign` with type
 
 ```lean
-assignExprMVar (mvarId : MVarId) (val : Expr) : MetaM Unit
+assign (mvarId : MVarId) (val : Expr) : MetaM Unit
 ```
 
 This updates the `MetavarContext` with the assignment `?mvarId := val`. You must
@@ -199,17 +199,22 @@ assigned value, `val`, has the right type. This means (a) that `val` must have
 the target type of `mvarId` and (b) that `val` must only contain fvars from the
 local context of `mvarId`.
 
-To get information about a declared metavariable, use `Lean.Meta.getMVarDecl`.
+If you `#check Lean.MVarId.assign`, you will see that its real type is more
+general than the one we showed above: it works in any monad that has access to a
+`MetavarContext`. But `MetaM` is by far the most important such monad, so in
+this chapter, we specialise the types of `assign` and similar functions.
+
+To get information about a declared metavariable, use `Lean.MVarId.getDecl`.
 Given an `MVarId`, this returns a `MetavarDecl` structure. (If no metavariable
 with the given `MVarId` is declared, the function throws an exception.) The
 `MetavarDecl` contains information about the metavariable, e.g. its type, local
 context and user-facing name. This function has some convenient variants, such
-as `Lean.Meta.getMVarType`.
+as `Lean.MVarId.getType`.
 
 To get the current assignment of a metavariable (if any), use
-`Lean.Meta.getExprMVarAssignment?`. To check whether a metavariable is assigned,
-use `Lean.Meta.isExprMVarAssigned`. However, these functions are relatively
-rarely used in tactic code because we usually prefer a more powerful operation:
+`Lean.getExprMVarAssignment?`. To check whether a metavariable is assigned, use
+`Lean.MVarId.isAssigned`. However, these functions are relatively rarely
+used in tactic code because we usually prefer a more powerful operation:
 `Lean.Meta.instantiateMVars` with type
 
 ```lean
@@ -240,11 +245,11 @@ sections.
 ```lean
 #eval show MetaM Unit from do
   -- Create two fresh metavariables of type `Nat`.
-  let mvar1 ← mkFreshExprMVar (mkConst ``Nat) (userName := `mvar1)
-  let mvar2 ← mkFreshExprMVar (mkConst ``Nat) (userName := `mvar2)
+  let mvar1 ← mkFreshExprMVar (Expr.const ``Nat []) (userName := `mvar1)
+  let mvar2 ← mkFreshExprMVar (Expr.const ``Nat []) (userName := `mvar2)
   -- Create a fresh metavariable of type `Nat → Nat`. The `mkArrow` function
   -- creates a function type.
-  let mvar3 ← mkFreshExprMVar (← mkArrow (mkConst ``Nat) (mkConst ``Nat))
+  let mvar3 ← mkFreshExprMVar (← mkArrow (.const ``Nat []) (.const ``Nat []))
     (userName := `mvar3)
 
   -- Define a helper function that prints each metavariable.
@@ -257,17 +262,17 @@ sections.
   printMVars
 
   -- Assign `mvar1 : Nat := ?mvar3 ?mvar2`.
-  assignExprMVar mvar1.mvarId! (mkApp mvar3 mvar2)
+  mvar1.mvarId!.assign (.app mvar3 mvar2)
   IO.println "After assigning mvar1:"
   printMVars
 
   -- Assign `mvar2 : Nat := 0`.
-  assignExprMVar mvar2.mvarId! (mkConst ``Nat.zero)
+  mvar2.mvarId!.assign (.const ``Nat.zero [])
   IO.println "After assigning mvar2:"
   printMVars
 
   -- Assign `mvar3 : Nat → Nat := Nat.succ`.
-  assignExprMVar mvar3.mvarId! (mkConst ``Nat.succ)
+  mvar3.mvarId!.assign (.const ``Nat.succ [])
   IO.println "After assigning mvar3:"
   printMVars
 -- Initially, all metavariables are unassigned:
@@ -294,7 +299,7 @@ Consider the expression `e` which refers to the free variable with unique name
 `h`:
 
 ```lean
-e := mkFVar (FVarId.mk `h)
+e := .fvar (FVarId.mk `h)
 ```
 
 What is the type of this expression? The answer depends on the local context in
@@ -313,17 +318,17 @@ we always have access to an ambient `LocalContext`, obtained with `Lean.getLCtx`
 of type
 
 ```lean
-getLCtx : MetaM LocalContext -- real type is more general
+getLCtx : MetaM LocalContext
 ```
 
 All operations involving fvars use this ambient local context.
 
 The downside of this setup is that we always need to update the ambient local
 context to match the goal we are currently working on. To do this, we use
-`Lean.Meta.withMVarContext` of type (again specialized)
+`Lean.MVarId.withContext` of type
 
 ```lean
-withMVarContext (mvarId : MVarId) (c : MetaM α) : MetaM α
+withContext (mvarId : MVarId) (c : MetaM α) : MetaM α
 ```
 
 This function takes a metavariable `mvarId` and a `MetaM` computation `c` and
@@ -332,7 +337,7 @@ typical use case looks like this:
 
 ```lean
 def someTactic (mvarId : MVarId) ... : ... :=
-  withMVarContext mvarId do
+  mvarId.withContext do
     ...
 ```
 
@@ -344,7 +349,7 @@ Once we have the local context properly set, we can manipulate fvars. Like
 metavariables, fvars are identified by an `FVarId` (a unique `Name`). Basic
 operations include:
 
-- `Lean.Meta.getLocalDecl : FVarId → MetaM LocalDecl` retrieves the declaration
+- `Lean.FVarId.getDecl : FVarId → MetaM LocalDecl` retrieves the declaration
   of a local hypothesis. As with metavariables, a `LocalDecl` contains all
   information pertaining to the local hypothesis, e.g. its type and its
   user-facing name.
@@ -358,36 +363,36 @@ instance of `LocalContext`. A typical pattern is this:
 
 ```lean
 for ldecl in ← getLCtx do
-  if ldecl.isAuxDecl then
+  if ldecl.isImplementationDetail then
     continue
   -- do something with the ldecl
 ```
 
-The loop iterates over every `LocalDecl` in the context. The `isAuxDecl` check
-skips so-called auxiliary declarations. These are local hypotheses which are
-inserted by the equation compiler, are invisible to the user and must be ignored
-by tactics.
+The loop iterates over every `LocalDecl` in the context. The
+`isImplementationDetail` check skips local hypotheses which are 'implementation
+details', meaning they are introduced by Lean or by tactics for bookkeeping
+purposes. They are not shown to users and tactics are expected to ignore them.
 
 At this point, we can build the `MetaM` part of an `assumption` tactic:
 
 ```lean
 def myAssumption (mvarId : MVarId) : MetaM Bool := do
   -- Check that `mvarId` is not already assigned.
-  checkNotAssigned mvarId `myAssumption
+  mvarId.checkNotAssigned `myAssumption
   -- Use the local context of `mvarId`.
-  withMVarContext mvarId do
+  mvarId.withContext do
     -- The target is the type of `mvarId`.
-    let target ← getMVarType mvarId
+    let target ← mvarId.getType
     -- For each hypothesis in the local context:
     for ldecl in ← getLCtx do
-      -- If the hypothesis is an auxiliary declaration, skip it.
-      if ldecl.isAuxDecl then
+      -- If the hypothesis is an implementation detail, skip it.
+      if ldecl.isImplementationDetail then
         continue
       -- If the type of the hypothesis is definitionally equal to the target
       -- type:
       if ← isDefEq ldecl.type target then
         -- Use the local hypothesis to prove the goal.
-        assignExprMVar mvarId ldecl.toExpr
+        mvarId.assign ldecl.toExpr
         -- Stop and return true.
         return true
     -- If we have not found any suitable local hypothesis, return false.
@@ -396,13 +401,13 @@ def myAssumption (mvarId : MVarId) : MetaM Bool := do
 
 The `myAssumption` tactic contains three functions we have not seen before:
 
-- `Lean.Meta.checkNotAssigned` checks that a metavariable is not already
+- `Lean.MVarId.checkNotAssigned` checks that a metavariable is not already
   assigned. The 'myAssumption' argument is the name of the current tactic. It is
   used to generate a nicer error message.
 - `Lean.Meta.isDefEq` checks whether two definitions are definitionally equal.
   See the [Definitional Equality section](#definitional-equality).
-- `Lean.LocalDecl.toExpr` is a helper function which constructs the expression
-  corresponding to a local hypothesis.
+- `Lean.LocalDecl.toExpr` is a helper function which constructs the `fvar`
+  expression corresponding to a local hypothesis.
 
 
 ### Delayed Assignments
@@ -416,9 +421,9 @@ useful for tactic writing. If you want to learn more about them, see the
 comments in `MetavarContext.lean` in the Lean standard library. But they create
 two complications which you should be aware of.
 
-First, delayed assignments make `isExprMVarAssigned` and
+First, delayed assignments make `Lean.MVarId.isAssigned` and
 `getExprMVarAssignment?` medium-calibre footguns. These functions only check for
-regular assignments, so you may need to use `Lean.Meta.isMVarDelayedAssigned`
+regular assignments, so you may need to use `Lean.MVarId.isDelayedAssigned`
 and `Lean.Meta.getDelayedMVarAssignment?` as well.
 
 Second, delayed assignments break an intuitive invariant. You may have assumed
@@ -460,7 +465,7 @@ Computation is a core concept of dependent type theory. The terms `2`, `Nat.succ
 1` and `1 + 1` are all "the same" in the sense that they compute the same value.
 We call them *definitionally equal*. The problem with this, from a
 metaprogramming perspective, is that definitionally equal terms may be
-represented by entirely different expressions, but still our users would usually
+represented by entirely different expressions, but our users would usually
 expect that a tactic which works for `2` also works for `1 + 1`. So when we
 write our tactics, we must do additional work to ensure that definitionally
 equal terms are treated similarly.
@@ -484,10 +489,10 @@ We can use it like this:
 ```lean
 def someNumber : Nat := (· + 2) $ 3
 
-#eval mkConst ``someNumber
+#eval Expr.const ``someNumber []
 -- Lean.Expr.const `someNumber []
 
-#eval reduce (mkConst ``someNumber)
+#eval reduce (Expr.const ``someNumber [])
 -- Lean.Expr.lit (Lean.Literal.natVal 5)
 ```
 
@@ -516,8 +521,8 @@ expression does not have a single normal form. Rather, it has a normal form up
 to a given *transparency*.
 
 A transparency is a value of `Lean.Meta.TransparencyMode`, an enumeration with
-four values: `reducible`, `instances`, `default` and `all`. Any computation in
-the `MetaM` has access to an ambient `TransparencyMode` which can be obtained
+four values: `reducible`, `instances`, `default` and `all`. Any `MetaM`
+computation has access to an ambient `TransparencyMode` which can be obtained
 with `Lean.Meta.getTransparency`.
 
 The current transparency determines which constants get unfolded during
@@ -542,32 +547,39 @@ pretty-print an expression):
 ```lean
 def traceConstWithTransparency (md : TransparencyMode) (c : Name) :
     MetaM Format := do
-  ppExpr (← withTransparency md $ reduce (mkConst c))
+  ppExpr (← withTransparency md $ reduce (.const c []))
 
 @[irreducible] def irreducibleDef : Nat      := 1
 def                defaultDef     : Nat      := irreducibleDef + 1
 abbrev             reducibleDef   : Nat      := defaultDef + 1
+```
 
+We start with `reducible` transparency, which only unfolds `reducibleDef`:
+
+```lean
 #eval traceConstWithTransparency .reducible ``reducibleDef
 -- defaultDef + 1
 ```
 
-Note that with `TransparencyMode.instances`, an instance of `HAdd Nat Nat`,
-which is used for the `+` notation, has also been unfolded:
+If we repeat the above command but let Lean print implicit arguments as well,
+we can see that the `+` notation amounts to an application of the `hAdd`
+function, which is a member of the `HAdd` typeclass:
 
 ```lean
--- the instance to be unfolded, `@instHAdd Nat instAddNat`,
--- can be seen when we pretty-print the implicit arguments below:
 set_option pp.explicit true
 #eval traceConstWithTransparency .reducible ``reducibleDef
 -- @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) defaultDef 1
-set_option pp.explicit false
+```
 
+When we reduce with `instances` transparency, this applications is unfolded and
+replaced by `Nat.add`:
+
+```lean
 #eval traceConstWithTransparency .instances ``reducibleDef
 -- Nat.add defaultDef 1
 ```
 
-With `TransparencyMode.default`, the `Nat.add` function is unfolded as well:
+With `default` transparency, `Nat.add` is unfolded as well:
 
 ```lean
 #eval traceConstWithTransparency .default ``reducibleDef
@@ -597,8 +609,8 @@ even more important is to recognise that for many purposes, we don't need to
 fully normalise terms at all. Suppose we are building a tactic that
 automatically splits hypotheses of the type `P ∧ Q`. We might want this tactic
 to recognise a hypothesis `h : X` if `X` reduces to `P ∧ Q`. But if `P`
-additionally reduces to `Y ∨ Z`, the specific `Y` and `Z` do not concern us:
-it's unnecessary extra computation that does not need to happen.
+additionally reduces to `Y ∨ Z`, the specific `Y` and `Z` do not concern us.
+Reducing `P` would be unnecessary work.
 
 This situation is so common that the fully normalising `reduce` is in fact
 rarely used. Instead, the normalisation workhorse of Lean is `whnf`, which
@@ -612,8 +624,8 @@ e = f x₁ ... xₙ   (n ≥ 0)
 ```
 
 and `f` cannot be reduced (at the current transparency). To conveniently check
-the WHNF of an expression, we define a function `whnf'` which uses some advanced
-tech; don't worry about its implementation for now.
+the WHNF of an expression, we define a function `whnf'`, using some functions
+that will be discussed in the Elaboration chapter.
 
 ```lean
 open Lean.Elab.Term in
@@ -683,7 +695,8 @@ h 0 1   -- Assuming `h` is a local hypothesis, it is in WHNF.
 
 On the flipside, here are some expressions that are not in WHNF.
 
-Applications of constants are not in WHNF:
+Applications of constants are not in WHNF if the current transparency allows us
+to unfold the constants:
 
 ```lean
 #eval whnf' `(List.append [1])
@@ -719,8 +732,7 @@ makes it easy:
 
 ```lean
 def matchAndReducing (e : Expr) : MetaM (Option (Expr × Expr)) := do
-  let e ← whnf e
-  match e with
+  match ← whnf e with
   | (.app (.app (.const ``And _) P) Q) => return some (P, Q)
   | _ => return none
 ```
@@ -736,11 +748,9 @@ this uses `whnf` twice:
 
 ```lean
 def matchAndReducing₂ (e : Expr) : MetaM (Option (Expr × Expr × Expr)) := do
-  let e ← whnf e
-  match e with
+  match ← whnf e with
   | (.app (.app (.const ``And _) P) e') =>
-    let e' ← whnf e'
-    match e' with
+    match ← whnf e' with
     | (.app (.app (.const ``And _) Q) R) => return some (P, Q, R)
     | _ => return none
   | _ => return none
@@ -774,11 +784,11 @@ the heuristics are good and `isDefEq` is reasonably fast.
 
 If expressions `t` and `u` contain assignable metavariables, `isDefEq` may
 assign these metavariables to make `t` defeq to `u`. We also say that `isDefEq`
-*unifies* `t` and `u`; unification queries are sometimes written `t =?= u`. For
-instance, the unification `List ?m =?= List Nat` succeeds and assigns `?m :=
+*unifies* `t` and `u`; such unification queries are sometimes written `t =?= u`.
+For instance, the unification `List ?m =?= List Nat` succeeds and assigns `?m :=
 Nat`. The unification `Nat.succ ?m =?= n + 1` succeeds and assigns `?m := n`.
-The unification `?m₁ + ?m₂ + ?m₃ =?= m + n - k` fails and no metavariables
-are assigned (even though there is a 'partial match' between the expressions).
+The unification `?m₁ + ?m₂ + ?m₃ =?= m + n - k` fails and no metavariables are
+assigned (even though there is a 'partial match' between the expressions).
 
 Whether `isDefEq` considers a metavariable assignable is determined by two
 factors:
@@ -798,9 +808,9 @@ factors:
 ## Constructing Expressions
 
 In the previous chapter, we saw some primitive functions for building
-expressions: `mkApp`, `mkConst` and so on. There is nothing wrong with these
-functions, but the additional facilities of `MetaM` often provide more
-convenient ways.
+expressions: `Expr.app`, `Expr.const`, `mkAppN` and so on. There is nothing
+wrong with these functions, but the additional facilities of `MetaM` often
+provide more convenient ways.
 
 
 ### Applications
@@ -827,8 +837,8 @@ above definition looks like this:
 
 ```lean
 def appendAppendRHSExpr₁ (u : Level) (α xs ys : Expr) : Expr :=
-  mkAppN (mkConst ``List.append [u])
-    #[α, mkAppN (mkConst ``List.append [u]) #[α, xs, ys], xs]
+  mkAppN (.const ``List.append [u])
+    #[α, mkAppN (.const ``List.append [u]) #[α, xs, ys], xs]
 ```
 
 Having to specify the implicit arguments and universe levels is annoying and
@@ -839,10 +849,10 @@ implicit information: `Lean.Meta.mkAppM` of type
 mkAppM : Name → Array Expr → MetaM Expr
 ```
 
-Like `mkAppN`, `mkAppM` constructs an application. But `mkAppN` requires us to
-give all universe levels and implicit arguments ourselves, `mkAppM` infers them.
-This means we only need to provide the explicit arguments, which makes for a
-much shorter example:
+Like `mkAppN`, `mkAppM` constructs an application. But while `mkAppN` requires
+us to give all universe levels and implicit arguments ourselves, `mkAppM` infers
+them. This means we only need to provide the explicit arguments, which makes for
+a much shorter example:
 
 ```lean
 def appendAppendRHSExpr₂ (xs ys : Expr) : MetaM Expr := do
@@ -875,7 +885,7 @@ def revOrd : Ord Nat where
   compare x y := compare y x
 
 def ordExpr : MetaM Expr := do
-  mkAppOptM ``compare #[none, mkConst ``revOrd, mkNatLit 0, mkNatLit 1]
+  mkAppOptM ``compare #[none, Expr.const ``revOrd [], mkNatLit 0, mkNatLit 1]
 
 #eval format <$> ordExpr
 -- Ord.compare.{0} Nat revOrd
@@ -897,25 +907,25 @@ to write out the lambda directly:
 
 ```lean
 def doubleExpr₁ : Expr :=
-  mkLambda `x BinderInfo.default (mkConst ``Nat)
-    (mkAppN (mkConst ``Nat.add) #[mkBVar 0, mkBVar 0])
+  .lam `x (.const ``Nat []) (mkAppN (.const ``Nat.add []) #[.bvar 0, .bvar 0])
+    BinderInfo.default
 
 #eval ppExpr doubleExpr₁
 -- fun x => Nat.add x x
 ```
 
-This works, but the use of `mkBVar` is highly unidiomatic. Lean uses a
-so-called *locally closed* variable representation. This means that all but the
+This works, but the use of `bvar` is highly unidiomatic. Lean uses a so-called
+*locally closed* variable representation. This means that all but the
 lowest-level functions in the Lean API expect expressions not to contain 'loose
 `bvar`s', where a `bvar` is loose if it is not bound by a binder in the same
-expression. (Such variables are more commonly called 'free'. The name `bvar` --
-'bound variable' -- already indicates that `bvar`s are never supposed to be
-free.)
+expression. (Outsied of Lean, such variables are usually called 'free'. The name
+`bvar` -- 'bound variable' -- already indicates that `bvar`s are never supposed
+to be free.)
 
 As a result, if in the above example we replace `mkAppN` with the slightly
 higher-level `mkAppM`, we get a runtime error. Adhering to the locally closed
 convention, `mkAppM` expects any expressions given to it to have no loose bound
-variables, and `mkBVar 0` obviously has one.
+variables, and `.bvar 0` is precisely that.
 
 So instead of using `bvar`s directly, the Lean way is to construct expressions
 with bound variables in two steps:
@@ -932,7 +942,7 @@ bespoke function). Applying the process to our example:
 
 ```lean
 def doubleExpr₂ : MetaM Expr :=
-  withLocalDecl `x BinderInfo.default (mkConst ``Nat) λ x => do
+  withLocalDecl `x BinderInfo.default (.const ``Nat []) λ x => do
     let body ← mkAppM ``Nat.add #[x, x]
     mkLambdaFVars #[x] body
 
@@ -949,9 +959,7 @@ withLocalDecl (name : Name) (bi : BinderInfo) (type : Expr) (k : Expr → MetaM 
 
 Given a variable name, binder info and type, `withLocalDecl` constructs a new
 `fvar` and passes it to the computation `k`. The `fvar` is avaible in the local
-context during the execution of `k` but is deleted again afterwards. (The real
-type of `withLocalDecl` is more general; it also works for monads which are
-built on top of `MetaM`.)
+context during the execution of `k` but is deleted again afterwards.
 
 The second new function is `Lean.Meta.mkLambdaFVars` with type (ignoring some
 optional arguments)
@@ -976,7 +984,7 @@ Some variants of the above functions may be useful:
   a function type `X → Y`. Since the type is non-dependent, there is no need
   for temporary `fvar`s.
 
-To further illustrate these concepts, we construct the expression
+Using all these functions, we can construct larger expressions such as this one:
 
 ```lean
 λ (f : Nat → Nat), ∀ (n : Nat), f n = f (n + 1)
@@ -984,11 +992,11 @@ To further illustrate these concepts, we construct the expression
 
 ```lean
 def somePropExpr : MetaM Expr := do
-  let funcType ← mkArrow (mkConst ``Nat) (mkConst ``Nat)
+  let funcType ← mkArrow (.const ``Nat []) (.const ``Nat [])
   withLocalDecl `f BinderInfo.default funcType fun f => do
-    let feqn ← withLocalDecl `n BinderInfo.default (mkConst ``Nat) fun n => do
-      let lhs := mkApp f n
-      let rhs := mkApp f (← mkAppM ``Nat.succ #[n])
+    let feqn ← withLocalDecl `n BinderInfo.default (.const ``Nat []) fun n => do
+      let lhs := .app f n
+      let rhs := .app f (← mkAppM ``Nat.succ #[n])
       let eqn ← mkEq lhs rhs
       mkForallFVars #[n] eqn
     mkLambdaFVars #[f] feqn
@@ -1021,7 +1029,7 @@ current target to determine whether `e` can be applied.
 To do this, we could repeatedly match on the type expression, removing `∀`
 binders until we get to `U`. But this would leave us with an `U` containing
 unbound `bvar`s, which, as we saw, is bad. Instead, we use
-`Lean.Meta.forallTelescope` of type (again specialized to `MetaM`)
+`Lean.Meta.forallTelescope` of type
 
 ```
 forallTelescope (type : Expr) (k : Array Expr → Expr → MetaM α) : MetaM α
@@ -1059,11 +1067,11 @@ Using one of the telescope functions, we can implement our own `apply` tactic:
 ```lean
 def myApply (goal : MVarId) (e : Expr) : MetaM (List MVarId) := do
   -- Check that the goal is not yet assigned.
-  checkNotAssigned goal `myApply
+  goal.checkNotAssigned `myApply
   -- Operate in the local context of the goal.
-  withMVarContext goal do
+  goal.withContext do
     -- Get the goal's target type.
-    let target ← getMVarType goal
+    let target ← goal.getType
     -- Get the type of the given expression.
     let type ← inferType e
     -- If `type` has the form `∀ (x₁ : T₁) ... (xₙ : Tₙ), U`, introduce new
@@ -1074,12 +1082,12 @@ def myApply (goal : MVarId) (e : Expr) : MetaM (List MVarId) := do
     if ← isDefEq target conclusion then
       -- Assign the goal to `e x₁ ... xₙ`, where the `xᵢ` are the fresh
       -- metavariables in `args`.
-      assignExprMVar goal (mkAppN e args)
+      goal.assign (mkAppN e args)
       -- `isDefEq` may have assigned some of the `args`. Report the rest as new
       -- goals.
       let newGoals ← args.filterMapM λ mvar => do
         let mvarId := mvar.mvarId!
-        if ! (← isExprMVarAssigned mvarId) && ! (← isMVarDelayedAssigned mvarId) then
+        if ! (← mvarId.isAssigned) && ! (← mvarId.isDelayedAssigned) then
           return some mvarId
         else
           return none
@@ -1108,7 +1116,8 @@ example (h : α → β) (a : α) : β := by
 Many tactics naturally require backtracking: the ability to go back to a
 previous state, as if the tactic had never been executed. A few examples:
 
-- `first | t | u` first executes `t`. If `t` fails, it backtracks and executes `u`.
+- `first | t | u` first executes `t`. If `t` fails, it backtracks and executes
+  `u`.
 - `try t` executes `t`. If `t` fails, it backtracks to the initial state,
   erasing any changes made by `t`.
 - `trivial` attempts to solve the goal using a number of simple tactics
@@ -1118,8 +1127,7 @@ previous state, as if the tactic had never been executed. A few examples:
 Good thing, then, that Lean's core data structures are designed to enable easy
 and efficient backtracking. The corresponding API is provided by the
 `Lean.MonadBacktrack` class. `MetaM`, `TermElabM` and `TacticM` are all
-instances of this class. (`CoreM` is not but could be; apparently the Lean
-compiler does not need this instance.)
+instances of this class. (`CoreM` is not but could be.)
 
 `MonadBacktrack` provides two fundamental operations:
 
@@ -1148,7 +1156,7 @@ The standard library defines many combinators like `tryM`. Here are the most
 useful ones:
 
 - `Lean.withoutModifyingState (x : m α) : m α` executes the action `x`, then
-  resets the state and returns `x`'s result. You can use this, for instance, to
+  resets the state and returns `x`'s result. You can use this, for example, to
   check for definitional equality without assigning metavariables:
   ```lean
   withoutModifyingState $ isDefEq x y


### PR DESCRIPTION
This PR ended up as a bit of a pile of stuff, but hopefully each point is uncontroversial.

* Update Lean to recent nightly.
* Avoid deprecated `MetaM` functions like `withMVarContext`.
* Avoid `mkConst` in favour of `Expr.const`, and the same for other `Expr` constructors.
* Use `isImplementationDetail` instead of `isAuxDecl`.
* Various improved formulations.

fixes #68
fixes #76

---

Btw I noticed that the deprecation linter didn't flag our use of deprecated functions. Any idea why this might be?