### PR TITLE
Enable pdf generation in prs; fix chapter structure

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build Some LaTeX
       run: |
         pandoc --to latex md/cover.md $(grep -o '\(md/.*\.md\)' README.md | tr -d '(' | tr -d ')') --toc --template ./eisvogel.latex --top-level-division=chapter -V documentclass=book -V classoption=oneside --no-highlight |
-          sed -e 's/\\begin{verbatim}/\\begin{minted}{Lean}/' -e 's/{verbatim}/{minted}/' -e's/% Listings/\\usepackage{minted}\n\\newmintinline[lean]{pygments\/lean4.py:Lean4Lexer -x}{bgcolor=white}\n\\newminted[leancode]{pygments\/lean4.py:Lean4Lexer -x}{fontsize=\\footnotesize}\n\\setminted{fontsize=\\footnotesize, breaklines}\n/' >out.tex
+          sed -e 's/\\begin{verbatim}/\\begin{minted}{Lean}/' -e 's/{verbatim}/{minted}/' -e's/% Listings/\\usepackage{minted}\n\\newmintinline[lean]{pygments\/lean4.py:Lean4Lexer -x}{bgcolor=f6f8fa}\n\\newminted[leancode]{pygments\/lean4.py:Lean4Lexer -x}{fontsize=\\footnotesize}\n\\setminted{fontsize=\\footnotesize, breaklines}\n/' >out.tex
 
     - name: Build a PDF
       # Running twice appears to be necessary to not get a blank TOC?!

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,9 +1,6 @@
 name: Book
 
-on:
-  push:
-    branches:
-      - master
+on: [push]
 
 jobs:
   book:
@@ -31,7 +28,15 @@ jobs:
       # Minted doesn't like filenames with spaces in them unfortunately, so we mv.
       run: mv out.tex 'Metaprogramming in Lean 4.tex' && mv out.pdf 'Metaprogramming in Lean 4.pdf'
 
+    - name: Upload PDF to artifact storage
+      if: github.ref != 'refs/heads/master'
+      uses: actions/upload-artifact@v3
+      with:
+        name: "Metaprogramming in Lean 4"
+        path: "Metaprogramming in Lean 4.pdf"
+
     - uses: "marvinpinto/action-automatic-releases@latest"
+      if: github.ref == 'refs/heads/master'
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build Some LaTeX
       run: |
         pandoc --to latex md/cover.md $(grep -o '\(md/.*\.md\)' README.md | tr -d '(' | tr -d ')') --toc --template ./eisvogel.latex --top-level-division=chapter -V documentclass=book -V classoption=oneside --no-highlight |
-          sed -e 's/\\begin{verbatim}/\\begin{minted}{Lean}/' -e 's/{verbatim}/{minted}/' -e's/% Listings/\\usepackage{minted}\n\\newmintinline[lean]{pygments\/lean4.py:Lean4Lexer -x}{bgcolor=f6f8fa}\n\\newminted[leancode]{pygments\/lean4.py:Lean4Lexer -x}{fontsize=\\footnotesize}\n\\setminted{fontsize=\\footnotesize, breaklines}\n/' >out.tex
+          sed -e 's/\\begin{verbatim}/\\begin{minted}{Lean}/' -e 's/{verbatim}/{minted}/' -e's/% Listings/\\usepackage{minted}\n\\newmintinline[lean]{pygments\/lean4.py:Lean4Lexer -x}{bgcolor=white}\n\\newminted[leancode]{pygments\/lean4.py:Lean4Lexer -x}{fontsize=\\footnotesize}\n\\setminted{fontsize=\\footnotesize, breaklines}\n/' >out.tex
 
     - name: Build a PDF
       # Running twice appears to be necessary to not get a blank TOC?!

--- a/lean/cover.lean
+++ b/lean/cover.lean
@@ -1,8 +1,8 @@
 /-
 ---
 title: "Metaprogramming in Lean 4"
-author: [Arthur Paulino, Damiano Testa, Edward Ayers, Evgenia Karunus, Henrik Böving,
-         Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
+author: [Arthur Paulino, Damiano Testa, Edward Ayers, Evgenia Karunus,
+        Henrik Böving, Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
 # abusing this field just because the template puts it at a decent right-sized spot
 date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https://github.com/Wandmalfarbe/pandoc-latex-template)"
 mainfont: "DejaVu Serif"

--- a/lean/extra/pretty-printing.lean
+++ b/lean/extra/pretty-printing.lean
@@ -1,4 +1,4 @@
-/- # Pretty Printing
+/- # Extra: Pretty Printing
 The pretty printer is what Lean uses to present terms that have been
 elaborated to the user. This is done by converting the `Expr`s back into
 `Syntax` and then even higher level pretty printing datastructures. This means

--- a/lean/main/expressions.lean
+++ b/lean/main/expressions.lean
@@ -253,7 +253,7 @@ set_option pp.explicit true in
 things, allows us to more conveniently construct and destruct larger
 expressions.
 
-# Exercises
+## Exercises
 
 1. Create expression `1 + 2` with `Expr.app`.
 2. Create expression `1 + 2` with `Lean.mkAppN`.

--- a/lean/main/metam.lean
+++ b/lean/main/metam.lean
@@ -1207,7 +1207,7 @@ you've already seen several glimpses in this chapter. We start by discussing
 Lean's syntax system, which allows you to add custom syntactic constructs to the
 Lean parser.
 
-# Exercises
+## Exercises
 
 1. [**Metavariables**] Create a metavariable with type `Nat`, and assign to it value `3`.
 Notice that changing the type of the metavarible from `Nat` to, for example, `String`, doesn't raise any errors - that's why, as was mentioned, we must make sure *"(a) that `val` must have the target type of `mvarId` and (b) that `val` must only contain `fvars` from the local context of `mvarId`"*.

--- a/lean/solutions/expressions.lean
+++ b/lean/solutions/expressions.lean
@@ -1,7 +1,8 @@
 import Lean
 open Lean Meta
 
-/- # Expressions: Solutions -/
+/- # Solutions -/
+/- ## Expressions: Solutions -/
 
 /- 1. Create expression `1 + 2` with `Expr.app`. -/
 def one : Expr :=

--- a/lean/solutions/metam.lean
+++ b/lean/solutions/metam.lean
@@ -1,7 +1,7 @@
 import Lean
 open Lean Meta
 
-/- # `MetaM`: Solutions -/
+/- ## `MetaM`: Solutions -/
 
 /- 1. [**Metavariables**] Create a metavariable with type `Nat`, and assign to it value `3`.
 Notice that changing the type of the metavarible from `Nat` to, for example, `String`, doesn't raise any errors - that's why, as was mentioned, we must make sure *"(a) that `val` must have the target type of `mvarId` and (b) that `val` must only contain `fvars` from the local context of `mvarId`".* -/

--- a/md/cover.md
+++ b/md/cover.md
@@ -1,7 +1,7 @@
 ---
 title: "Metaprogramming in Lean 4"
-author: [Arthur Paulino, Damiano Testa, Edward Ayers, Henrik Böving,
-         Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
+author: [Arthur Paulino, Damiano Testa, Edward Ayers, Evgenia Karunus,
+        Henrik Böving, Jannis Limperg, Siddhartha Gadgil, Siddharth Bhat]
 # abusing this field just because the template puts it at a decent right-sized spot
 date: "Formatted for PDF by Julian Berman using [Pascal Wagler's Template](https://github.com/Wandmalfarbe/pandoc-latex-template)"
 mainfont: "DejaVu Serif"

--- a/md/extra/pretty-printing.md
+++ b/md/extra/pretty-printing.md
@@ -1,4 +1,4 @@
-# Pretty Printing
+# Extra: Pretty Printing
 The pretty printer is what Lean uses to present terms that have been
 elaborated to the user. This is done by converting the `Expr`s back into
 `Syntax` and then even higher level pretty printing datastructures. This means

--- a/md/main/expressions.md
+++ b/md/main/expressions.md
@@ -268,7 +268,7 @@ In the next chapter we explore the `MetaM` monad, which, among many other
 things, allows us to more conveniently construct and destruct larger
 expressions.
 
-# Exercises
+## Exercises
 
 1. Create expression `1 + 2` with `Expr.app`.
 2. Create expression `1 + 2` with `Lean.mkAppN`.

--- a/md/main/metam.md
+++ b/md/main/metam.md
@@ -1205,7 +1205,7 @@ you've already seen several glimpses in this chapter. We start by discussing
 Lean's syntax system, which allows you to add custom syntactic constructs to the
 Lean parser.
 
-# Exercises
+## Exercises
 
 1. [**Metavariables**] Create a metavariable with type `Nat`, and assign to it value `3`.
 Notice that changing the type of the metavarible from `Nat` to, for example, `String`, doesn't raise any errors - that's why, as was mentioned, we must make sure *"(a) that `val` must have the target type of `mvarId` and (b) that `val` must only contain `fvars` from the local context of `mvarId`"*.

--- a/md/solutions/expressions.md
+++ b/md/solutions/expressions.md
@@ -3,7 +3,9 @@ import Lean
 open Lean Meta
 ```
 
-# Expressions: Solutions
+# Solutions
+
+## Expressions: Solutions
 
 1. Create expression `1 + 2` with `Expr.app`.
 

--- a/md/solutions/expressions.md
+++ b/md/solutions/expressions.md
@@ -131,14 +131,14 @@ def nine : Expr :=
   Expr.lam `p (Expr.sort Lean.Level.zero)
   (
     Expr.lam `hP (Expr.bvar 0)
-    (Expr.bvar 1)
+    (Expr.bvar 0)
     BinderInfo.default
   )
   BinderInfo.default
 
 elab "nine" : term => return nine
-#check nine  -- fun p hP => p : (p : Prop) → p → Prop
-#reduce nine -- fun p hP => p
+#check nine  -- fun p hP => hP : ∀ (p : Prop), p → p
+#reduce nine -- fun p hP => hP
 ```
 
 10. [**Universe levels**] Create expression `Type 6`.

--- a/md/solutions/metam.md
+++ b/md/solutions/metam.md
@@ -3,7 +3,7 @@ import Lean
 open Lean Meta
 ```
 
-# `MetaM`: Solutions
+## `MetaM`: Solutions
 
 1. [**Metavariables**] Create a metavariable with type `Nat`, and assign to it value `3`.
 Notice that changing the type of the metavarible from `Nat` to, for example, `String`, doesn't raise any errors - that's why, as was mentioned, we must make sure *"(a) that `val` must have the target type of `mvarId` and (b) that `val` must only contain `fvars` from the local context of `mvarId`".*


### PR DESCRIPTION
## In this PR:

- [x] Generate all `.md` files
       
   >  **Explanation**: In previous PR I thought `.md` files will be automatically generated on push to master, they weren't, so pushing the final `.md` generation in this PR.
- [x] Put exercises within chapters in a pdf, mark **Pretty Printing** as **Extra**, make **Solutions** a separate chapter

  > From → to
  >
  > <img height="300" alt="image" src="https://user-images.githubusercontent.com/7578559/212422719-c581d34e-0251-4474-a5d7-375708b2f5d1.png"> <img height="300" alt="image" src="https://user-images.githubusercontent.com/7578559/212422682-29475d75-05db-43e0-81d1-a70b3ca00d9f.png">


- [x] Enable pdf generation in PRs

  > **Explanation**: like [Julian mentioned](https://github.com/arthurpaulino/lean4-metaprogramming-book/pull/32#issue-1261345911), there are 2 ways to generate a pdf - via **actions/upload-artifact** (makes it possible to download an artifact [from the artifacts section in actions tab] in a zip file; and then unzip it; and then see the pdf) and via **marvinpinto/action-automatic-releases** (automatically creates a release on each push, and makes the pdf directly available via that release).
  >
  > This PR makes it so that we do **marvinpinto/action-automatic-releases** when we push to master, and **actions/upload-artifact** when we push to any other branch (so that we can check out the generated pdf).
  
## Gotchas

I can now see the generated pdf in my forked branch, however the new workflow doesn't run in *this* repo for some reason. Maybe this will work upon the creation of further PRs after this is merged, or maybe [some permission](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-required-approval-for-workflows-from-public-forks) needs to be set by Arthur, will be more clear on further PRs.