### PR TITLE
Add Ch.Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ A PDF is [available here for download](../../releases/download/latest/Metaprogra
 
 * Main
     1. [Introduction](md/main/intro.md)
-    2. [Expressions](md/main/expressions.md)
-    3. [`MetaM`](md/main/metam.md)
-    4. [`Syntax`](md/main/syntax.md)
-    5. [Macros](md/main/macros.md)
-    6. [Elaboration](md/main/elaboration.md)
-    7. [DSLs](md/main/dsls.md)
-    8. [Tactics](md/main/tactics.md)
-    9. [Cheat sheet](md/main/cheat-sheet.md)
+    2. [Overview](md/main/overview.md)
+    3. [Expressions](md/main/expressions.md)
+    4. [`MetaM`](md/main/metam.md)
+    5. [`Syntax`](md/main/syntax.md)
+    6. [Macros](md/main/macros.md)
+    7. [Elaboration](md/main/elaboration.md)
+    8. [DSLs](md/main/dsls.md)
+    9. [Tactics](md/main/tactics.md)
+    10. [Cheat sheet](md/main/cheat-sheet.md)
 * Extra
     1. [Options](md/extra/options.md)
     2. [Attributes](md/extra/attributes.md)

--- a/lean/main/intro.lean
+++ b/lean/main/intro.lean
@@ -6,7 +6,8 @@
 This book aims to build up enough knowledge about metaprogramming in Lean 4 so
 you can be comfortable enough to:
 
-* Start building your own meta helpers
+* Start building your own meta helpers (defining new Lean notation such as `∑`,
+building new Lean commands such as `#check`, writing your own tactics such as `use`, etc.)
 * Read and discuss metaprogramming API's like the ones in Lean 4 core and
 Mathlib4
 
@@ -20,7 +21,7 @@ is a highly recommended source on that subject.
 
 ## Book structure
 
-The book is organized in a way to build up enough content for the chapters that
+The book is organized in a way to build up enough context for the chapters that
 cover DSLs and tactics. Backtracking the pre-requisites for each chapter, the
 dependency structure is as follows:
 
@@ -31,8 +32,8 @@ dependency structure is as follows:
 * "`MetaM`" builds on top of "Expressions"
 
 After the chapter on tactics, you find a cheat-sheet containing a wrap-up of key
-concepts and functions. And after that, There are some chapters with extra
-content, showing other applications of metaprogramming in Lean 4.
+concepts and functions. And after that, there are some chapters with extra
+content, showing other applications of metaprogramming in Lean 4. Most chapters contain exercises in the end of the chapter - and in the end of the book you will have full solutions to those exercises.  
 
 The rest of this chapter is a gentle introduction for what metaprogramming is,
 offering some small examples to serve as appetizers for what the book shall
@@ -47,8 +48,8 @@ When we write code in most programming languages such as Python, C, Java or
 Scala, we usually have to stick to a pre-defined syntax otherwise the compiler
 or the interpreter won't be able to figure out what we're trying to say. In
 Lean, that would be defining an inductive type, implementing a function, proving
-a theorem etc. The compiler, then, has to parse the code, build an abstract
-syntax tree and elaborate its syntax nodes into terms that can be processed by
+a theorem, etc. The compiler, then, has to parse the code, build an AST (abstract
+syntax tree) and elaborate its syntax nodes into terms that can be processed by
 the language kernel. We say that such activities performed by the compiler are
 done in the __meta-level__, which will be studied throughout the book. And we
 also say that the common usage of the language syntax is done in the
@@ -56,32 +57,38 @@ __object-level__.
 
 In most systems, the meta-level activities are done in a different language to
 the one that we use to write code. In Isabelle, the meta-level language is ML
-and Scala. In Coq, it's OCaml. In Agda it's Haskell. In Lean 4, the meta code is
+and Scala. In Coq, it's OCaml. In Agda, it's Haskell. In Lean 4, the meta code is
 mostly written in Lean itself, with a few components written in C++.
 
 One cool thing about Lean, though, is that it allows us to define custom syntax
 nodes and to implement our own meta-level routines to elaborate those in the
 very same development environment that we use to perform object-level
 activities. So for example, one can write their own notation to instantiate a
-term of a certain type and use it right away, on the same file! This concept is
+term of a certain type and use it right away, in the same file! This concept is
 generally called
 [__reflection__](https://en.wikipedia.org/wiki/Reflective_programming). We can
 say that, in Lean, the meta-level is _reflected_ to the object-level.
 
-Since the objects defined in the meta-level are not the ones we're most
-interested in proving theorems about, it can sometimes be overly tedious to
-prove that they are type correct. For example, we don't care about proving that
-a recursive function to traverse an expression is well founded. Thus, we can
-use the `partial` keyword if we're convinced that our function terminates. In
-the worst case scenario, our function gets stuck in a loop but the kernel is
-not reached/affected.
+If you have done some metaprogramming in languages such as Ruby, Python or Javascript,
+it probably took a form of making use of predefined metaprogramming methods in order to define
+something on the fly. For example, in Ruby you can use `Class.new` and `define_method`
+to define a new class and its new method (with new code inside!) on the fly, as your program is executing.
 
-Let's see some example use cases of metaprogramming in Lean.
+We don't usually need to define new commands or tactics "on the fly" in Lean, but spiritually
+similar feats are possible with Lean metaprogramming, and are equally straightforward, e.g. you can define
+a new Lean command using a simple one-liner `elab "#help" : command => do ...normal Lean code...`.
+
+In Lean, however, we will frequently want to directly manipulate
+Lean's CST (Concrete Syntax Tree, Lean's `Syntax` type) and
+Lean's AST (Abstract Syntax Tree, Lean's `Expr` type) instead of using "normal Lean code",
+especially when we're writing tactics. So Lean metaprogramming is more challenging to master -
+a large chunk of this book is contributed to studying these types and how we can manipulate them.
 
 ## Metaprogramming examples
 
-The following examples are meant for mere illustration. Don't worry if you don't
-understand the details for now.
+Next, we introduce a number of examples of Lean metaprogramming, so that you start getting a taste for
+what metaprogramming in Lean is, and what it will enable you to achieve. These examples are meant as
+mere illustration - do not worry if you don't understand the details for now.
 
 ### Introducing notation (defining new syntax)
 
@@ -246,22 +253,4 @@ To require the proof of the new hypothesis as a goal, we call `replaceMainGoal`
 passing a list with `p.mvarId!` in the head. And then we can use the
 `rotate_left` tactic to move the recently added top goal to the bottom.
 
-## Printing Messages
-
-In the `#assertType` example, we used `logInfo` to make our command print
-something. If, instead, we just want to perform a quick debug, we can use
-`dbg_trace`.
-
-They behave a bit differently though, as we can see below:
 -/
-
-elab "traces" : tactic => do
-  let array := List.replicate 2 (List.range 3)
-  Lean.logInfo m!"logInfo: {array}"
-  dbg_trace f!"dbg_trace: {array}"
-
-example : True := by -- `example` is underlined in blue, outputting:
-                     -- dbg_trace: [[0, 1, 2], [0, 1, 2]]
-  traces -- now `traces` is underlined in blue, outputting
-         -- logInfo: [[0, 1, 2], [0, 1, 2]]
-  trivial

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -79,7 +79,7 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 
 This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 non-syntax-sugary commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
 
-If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see "*"Displays proof in a Fitch table""* logged in VSCode's infoview.
+If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
 
 If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -11,8 +11,9 @@ Metaprogramming in Lean is deeply connected to the compilation steps - parsing, 
 >
 > Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
 
-
-<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>  
+<p align="center">
+<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>
+</p>
 
 First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
 So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
@@ -76,7 +77,9 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
+<p align="center">
 <img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+</p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
 
@@ -88,7 +91,7 @@ Let's consider **Syntax → Expr** commands:
 
 - `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
 
-- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab` 
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
 
 Let's consider **Syntax → Expr** commands:
 
@@ -148,7 +151,9 @@ The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from th
 
 Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
 
+<p align="center">
 <img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+</p>
 
 Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -212,6 +212,7 @@ interested in proving theorems about, it can sometimes be overly tedious to
 prove that they are type correct. For example, we don't care about proving that
 a recursive function to traverse an expression is well founded. Thus, we can
 use the `partial` keyword if we're convinced that our function terminates. In
-the worst case scenario, our function gets stuck in a loop but the kernel is
-not reached/affected.
+the worst case scenario, our function gets stuck in a loop, Lean server crashes
+in VSCode, but the soundness of the underlying type theory implemented in kernel
+isn't affected.
 -/

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -1,7 +1,9 @@
 /-
 # Overview
 
-In this chapter, we will go through the fundamental concepts behind Lean metaprogramming, and how they interact. In the next chapters, you will learn the particulars. As you read on, you might want to return to this chapter occasionally to remind yourself of how it all fits together.
+In this chapter, we will provide an overview of the primary steps involved in the Lean compilation process, including parsing, elaboration, and evaluation. As alluded to in the introduction, metaprogramming in Lean involves plunging into the heart of this process. We will explore the fundamental objects involved, `Expr` and `Syntax`, learn what they signify, and discover how one can be turned into another (and back!).
+
+In the next chapters, you will learn the particulars. As you read on, you might want to return to this chapter occasionally to remind yourself of how it all fits together.
 
 ## Connection to compilers
 
@@ -11,11 +13,14 @@ Metaprogramming in Lean is deeply connected to the compilation steps - parsing, 
 >
 > Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
 
+Lean compilation process can be summed up in the following diagram:
+
 <p align="center">
 <img width="700px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/78867009-2624-46a3-a1f4-f488fd25d494"/>
 </p>
 
 First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
+
 So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
 
 1. **apply a relevant `syntax` rule** (`"let a := 2"` ➤ `Syntax`)  
@@ -28,7 +33,7 @@ So, the compiler sees a string of Lean code, say `"let a := 2"`, and the followi
 
 3. **apply a single `elab`** (`Syntax` ➤ `Expr`)  
 
-    Finally, it's time to infuse your syntax with meaning - Lean finds an `elab` rule that's matched to the appropriate `syntax` rule by the name argument (both the `syntax` rule and `elab` rule have this argument, and they must match). The newfound `elab` returns a particular `Expr` object.
+    Finally, it's time to infuse your syntax with meaning - Lean finds an `elab` rule that's matched to the appropriate `syntax` rule by the `:name` argument (both the `syntax` rule and `elab` rule have this argument, and they must match). The newfound `elab` returns a particular `Expr` object.
     This completes the elaboration step.
 
 Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
@@ -46,11 +51,13 @@ Elaboration is a loaded term in Lean, for example you can meet the following usa
 >
 > ([Theorem Proving in Lean 2](http://leanprover.github.io/tutorial/08_Building_Theories_and_Proofs.html))
 
-These definitions are not mutually exclusive - elaboration is the transformation of `Syntax` into `Expr`s - it's just so that for this transformation to happen we need a lot of trickery - we need to infer implicit arguments, instantiate metavariables, perform unification, resolve identifiers, etc. etc. - and these actions can be referred to as "elaboration" on their own; similarly to how "checking if you turned off the lights in your apartment" (metavariable instantiation) can be referred to as "going to school" (elaboration).
+We, on the other hand, just defined elaboration as the process of turning `Syntax` objects into `Expr` objects.
 
-There also exists a process opposite to elaboration in Lean - it's called, appropriately enough, delaboration. During delaboration, `Expr` is turned into the `Syntax` object; and then the formatter turns it into a `Format` object, which can be displayed in Lean's infoview. Every time you log something to the screen, or see some output upon hovering over `#check`, it's the work of delaborator.
+These definitions are not mutually exclusive - elaboration is, indeed, the transformation of `Syntax` into `Expr`s - it's just so that for this transformation to happen we need a lot of trickery - we need to infer implicit arguments, instantiate metavariables, perform unification, resolve identifiers, etc. etc. - and these actions can be referred to as "elaboration" on their own; similarly to how "checking if you turned off the lights in your apartment" (metavariable instantiation) can be referred to as "going to school" (elaboration).
 
-Throughout this book you will see references to the elaborator; and in the "Pretty Printing" extra chapter you can read on delaborators.
+There also exists a process opposite to elaboration in Lean - it's called, appropriately enough, delaboration. During delaboration, `Expr` is turned into the `Syntax` object; and then the formatter turns it into a `Format` object, which can be displayed in Lean's infoview. Every time you log something to the screen, or see some output upon hovering over `#check`, it's the work of the delaborator.
+
+Throughout this book you will see references to the elaborator; and in the "Extra: Pretty Printing" chapter you can read on delaborators.
 
 ## 3 essential functions and their syntax sugars
 
@@ -64,7 +71,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 - **macro: `@[macro xxx] def ourMacro : Macro := ...`**
 
     For example, ``@[macro xxx] def ourMacro : Macro := λ stx => match stx with | _ => `(tactic| pick_goal 2)``. Whenever your Lean code matches the syntax rule with the name `xxx`, this macro will be applied.  
-    If the syntax rule was syntax `(name := xxx) "swap" : tactic`, this macro will syntactically turn `swap` into `pick_goal 2` - and the subsequent elaboration step will be handled by the `pick_goal 2` syntax rule.
+    If the syntax rule was `syntax (name := xxx) "swap" : tactic`, this macro will syntactically turn `swap` into `pick_goal 2` - and the subsequent elaboration step will be handled by the `pick_goal 2` syntax rule.
 
 - **elab: `@[command_elab xxx] def ourElab : CommandElab := ...`**
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -12,7 +12,7 @@ Metaprogramming in Lean is deeply connected to the compilation steps - parsing, 
 > Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
 
 <p align="center">
-<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>
+<img width="700px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/78867009-2624-46a3-a1f4-f488fd25d494"/>
 </p>
 
 First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
@@ -78,7 +78,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+<img src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
 </p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
@@ -152,7 +152,7 @@ The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from th
 Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
 
 <p align="center">
-<img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+<img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/b403e650-dab4-4843-be8c-8fb812695a3a"/>
 </p>
 
 Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -77,11 +77,12 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 <img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command - *"Displays proof in a Fitch table"*.
 
-If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
+If we write `#h "#explode"`, Lean will travel the `syntax (name := shortcut_h)` ➤ `@[macro shortcut_h] def helpMacro` ➤ `syntax (name := default_h)` ➤ `@[command_elab default_h] def helpElab` route.  
+If we write `#help "#explode"`, Lean will travel the `syntax (name := default_h)` ➤ `@[command_elab default_h] def helpElab` route.
 
-If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
+Note how the matching between **syntax rules**, **macros**, and **elabs** is done via the `name` attribute. If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 
 If we were defining something other than a command, instead of `: command` we could write `: term`, or `: tactic`, or any other syntax category.  
 The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`:  

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -147,7 +147,9 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)).  
+
+So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -33,14 +33,14 @@ So, the compiler sees a string of Lean code, say `"let a := 2"`, and the followi
 
 3. **apply a single elab** (`Syntax` ➤ `Expr`)  
 
-    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** that's matched to the appropriate **syntax rule** by the `:name` argument (**macros**, **syntax rules** and **elabs** all have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
+    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** that's matched to the appropriate **syntax rule** by the `:name` argument (**syntax rules**, **macros** and **elabs** all have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
     This completes the elaboration step.
 
 Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
 
 ## Elaboration and delaboration
 
-Elaboration is a loaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
+Elaboration is a overloaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
 
 
 > When you enter an expression like `λ x y z, f (x + y) z` for Lean to process, you are leaving information implicit. For example, the types of `x`, `y`, and `z` have to be inferred from the context, the notation `+` may be overloaded, and there may be implicit arguments to `f` that need to be filled in as well.
@@ -69,7 +69,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 
 In the image above, you see `notation`, `prefix`, `infix`, and `postfix` - all of these are combinations of `syntax` and `@[macro xxx] def ourMacro`, just like `macro`. These commands differ from `macro` in that you can only define syntax of particular form with them.
 
-All of these commands are used in Lean and Mathlib source code extensively, so it's well worth memorizing them. Most of them are syntax sugars, however, and you can understand their behaviour by studying the behaviour of these 3 low-level commands: `syntax` (a **syntax rule**), `@[macro xxx] def ourMacro` (a **macro**), and `@[command_elab xxx] def ourElab` (an **elab**).
+All of these commands are used in Lean and Mathlib source code extensively, so it's well worth memorizing them. Most of them are syntax sugars, however, and you can understand their behaviour by studying the behaviour of the following 3 low-level commands: `syntax` (a **syntax rule**), `@[macro xxx] def ourMacro` (a **macro**), and `@[command_elab xxx] def ourElab` (an **elab**).
 
 To give a more concrete example, imagine we're implementing a `#help` command, that can also be written as `#h`. Then we can write our **syntax rule**, **macro**, and **elab** as follows:
 
@@ -77,18 +77,18 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 <img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 non-syntax-sugary commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
 
 If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
 
 If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 
 If we were defining something other than a command, instead of `: command` we could write `: term`, or `: tactic`, or any other syntax category.  
-The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`.  
+The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`:  
 
-`TermElab` stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
-`CommandElab` stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
-`Tactic` stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
+- `TermElab` stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
+- `CommandElab` stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+- `Tactic` stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
 
 This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -1,0 +1,193 @@
+/-
+# Overview
+
+In this chapter, we will go through the fundamental concepts behind Lean metaprogramming, and how they interact. In the next chapters, you will learn the particulars. As you read on, you might want to return to this chapter occasionally to remind yourself of how it all fits together.
+
+## Connection to compilers
+
+Metaprogramming in Lean is deeply connected to the compilation steps - parsing, syntactic analysis, transformation, and code generation.
+
+> Lean 4 is a reimplementation of the Lean theorem prover in Lean itself. The new compiler produces C code, and users can now implement efficient proof automation in Lean, compile it into efficient C code, and load it as a plugin. In Lean 4, users can access all internal data structures used to implement Lean by merely importing the Lean package.
+>
+> Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
+
+
+<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>  
+
+First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
+So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
+
+1. **apply a relevant `syntax` rule** (`"let a := 2"` ➤ `Syntax`)  
+
+    During the parsing step, Lean applies all declared `syntax` rules to turn a string of Lean code into the `Syntax` object. `syntax` rules are basically glorified regular expressions - when you write a Lean string that matches a certain `syntax` rule's regex, that rule will be used to handle subsequent steps.
+
+2. **apply all `macro`s in a loop** (`Syntax` ➤ `Syntax`)  
+
+    During the elaboration step, each `macro` simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more `macro`s to apply.
+
+3. **apply a single `elab`** (`Syntax` ➤ `Expr`)  
+
+    Finally, it's time to infuse your syntax with meaning - Lean finds an `elab` rule that's matched to the appropriate `syntax` rule by the name argument (both the `syntax` rule and `elab` rule have this argument, and they must match). The newfound `elab` returns a particular `Expr` object.
+    This completes the elaboration step.
+
+Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
+
+## Elaboration and delaboration
+
+Elaboration is a loaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
+
+
+> When you enter an expression like `λ x y z, f (x + y) z` for Lean to process, you are leaving information implicit. For example, the types of `x`, `y`, and `z` have to be inferred from the context, the notation `+` may be overloaded, and there may be implicit arguments to `f` that need to be filled in as well.
+>
+> The process of *taking a partially-specified expression and inferring what is left implicit* is known as **elaboration**. Lean's **elaboration** algorithm is powerful, but at the same time, subtle and complex. Working in a system of dependent type theory requires knowing what sorts of information the **elaborator** can reliably infer, as well as knowing how to respond to error messages that are raised when the elaborator fails. To that end, it is helpful to have a general idea of how Lean's **elaborator** works.
+>
+> When Lean is parsing an expression, it first enters a preprocessing phase. First, Lean inserts "holes" for implicit arguments. If term t has type `Π {x : A}, P x`, then t is replaced by `@t _` everywhere. Then, the holes — either the ones inserted in the previous step or the ones explicitly written by the user — in a term are instantiated by metavariables `?M1`, `?M2`, `?M3`, .... Each overloaded notation is associated with a list of choices, that is, the possible interpretations. Similarly, Lean tries to detect the points where a coercion may need to be inserted in an application `s t`, to make the inferred type of t match the argument type of `s`. These become choice points too. If one possible outcome of the elaboration procedure is that no coercion is needed, then one of the choices on the list is the identity.  
+>
+> ([Theorem Proving in Lean 2](http://leanprover.github.io/tutorial/08_Building_Theories_and_Proofs.html))
+
+These definitions are not mutually exclusive - elaboration is the transformation of `Syntax` into `Expr`s - it's just so that for this transformation to happen we need a lot of trickery - we need to infer implicit arguments, instantiate metavariables, perform unification, resolve identifiers, etc. etc. - and these actions can be referred to as "elaboration" on their own; similarly to how "checking if you turned off the lights in your apartment" (metavariable instantiation) can be referred to as "going to school" (elaboration).
+
+There also exists a process opposite to elaboration in Lean - it's called, appropriately enough, delaboration. During delaboration, `Expr` is turned into the `Syntax` object; and then the formatter turns it into a `Format` object, which can be displayed in Lean's infoview. Every time you log something to the screen, or see some output upon hovering over `#check`, it's the work of delaborator.
+
+Throughout this book you will see references to the elaborator; and in the "Pretty Printing" extra chapter you can read on delaborators.
+
+## 3 essential functions and their syntax sugars
+
+Now, when you're reading Lean source code, you will see 11(+?) commands specifying the **parsing**/**elaboration**/**evaluation** process.  Most of them are syntax sugar, and you only need **3 commands** to do metaprogramming in Lean:
+
+- **syntax rule: `syntax (name := xxx) ... : command`**
+
+    For example, `syntax (name := xxx) "#help" "option" (ident)? : command` is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.   
+    Other widespread syntax categories are `tactic` and `term`, all of these are used in different physical places in your code.
+
+- **macro: `@[macro xxx] def ourMacro : Macro := ...`**
+
+    For example, ``@[macro xxx] def ourMacro : Macro := λ stx => match stx with | _ => `(tactic| pick_goal 2)``. Whenever your Lean code matches the syntax rule with the name `xxx`, this macro will be applied.  
+    If the syntax rule was syntax `(name := xxx) "swap" : tactic`, this macro will syntactically turn `swap` into `pick_goal 2` - and the subsequent elaboration step will be handled by the `pick_goal 2` syntax rule.
+
+- **elab: `@[command_elab xxx] def ourElab : CommandElab := ...`**
+
+    For example, ``@[term_elab our_help] def ourElab : TermElab := λ stx tp => (Expr.app (Expr.const `Nat.add []))``.  
+    Our `elab` function can be of different types - the **CommandElab** and **TermElab** that you saw already, and **Tactic**.  
+    **TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elaboration function is expected to return the **Expr** object.  
+    **CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+    **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
+    This corresponds to out intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
+
+These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+
+<img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+
+In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
+
+Let's consider **Syntax → Expr** commands:
+
+- `syntax ~ : command` - low-level command we just discussed (I write `command` here for succinctness, but it can be `term`, `:tactic`, etc.).  
+
+- `@[command_elab ~] def ~ : CommandElab` - low-level command we just discussed (I write `CommandElab` here for succinctness, but it can be `Tactic`, `TermElab`, etc.).  
+
+- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
+
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab` 
+
+Let's consider **Syntax → Expr** commands:
+
+- `syntax ~ : command` - low-level command we just discussed.  
+
+- `@[macro] def ~ : Macro` - low-level command we just discussed.  
+
+- `macro_rules` - sugar for `@[macro] def ~ : Macro`.  
+
+- `macro` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`.  
+
+- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro` - they differ from `macro` in that you can only define rather simple syntax using them.
+
+## Order of execution: syntax, macro, elab
+
+We have hinted at the flow of execution of these three essential functions here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `(syntax; macro)+ elab`.
+
+Consider the following example.
+
+-/
+import Lean
+
+syntax (name := xxx) "red" : command
+syntax (name := yyy) "green" : command
+syntax (name := zzz) "blue" : command
+
+@[macro xxx] def redMacro : Lean.Macro := λ stx =>
+  match stx with
+  | _ => `(green)
+
+@[macro yyy] def greenMacro : Lean.Macro := λ stx =>
+  match stx with
+  | _ => `(blue)
+
+@[command_elab zzz] def blueElab : Lean.Elab.Command.CommandElab := λ stx =>
+  Lean.logInfo "finally, blue!"
+
+red -- finally, blue!
+
+/-
+
+The process is as follows:
+
+> match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
+> apply `@[macro xxx]` ➤
+>
+> match appropriate syntax rule (happens to have `name := yyy`) ➤  
+> apply `@[macro yyy]` ➤
+>
+> match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
+> can't find any macros with name `zzz` to apply,  
+> so apply `@[command_elab zzz]`.  🎉.
+
+The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from these first principles.
+
+## Manual conversions between `Syntax`/`Expr`/executable-code
+
+Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
+
+<img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+
+Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".
+
+## Assigning meaning: macro VS elaboration?
+
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" (Zulip thread)[https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290]. So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+
+## Additional comments
+
+Finally - some notes that should clarify a few things as you read the coming chapters.
+
+### Printing Messages
+
+In the `#assertType` example, we used `logInfo` to make our command print
+something. If, instead, we just want to perform a quick debug, we can use
+`dbg_trace`.
+
+They behave a bit differently though, as we can see below:
+-/
+
+elab "traces" : tactic => do
+  let array := List.replicate 2 (List.range 3)
+  Lean.logInfo m!"logInfo: {array}"
+  dbg_trace f!"dbg_trace: {array}"
+
+example : True := by -- `example` is underlined in blue, outputting:
+                     -- dbg_trace: [[0, 1, 2], [0, 1, 2]]
+  traces -- now `traces` is underlined in blue, outputting
+         -- logInfo: [[0, 1, 2], [0, 1, 2]]
+  trivial
+
+/-
+### Type correctness
+
+Since the objects defined in the meta-level are not the ones we're most
+interested in proving theorems about, it can sometimes be overly tedious to
+prove that they are type correct. For example, we don't care about proving that
+a recursive function to traverse an expression is well founded. Thus, we can
+use the `partial` keyword if we're convinced that our function terminates. In
+the worst case scenario, our function gets stuck in a loop but the kernel is
+not reached/affected.
+-/

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -75,35 +75,30 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
     **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
     This corresponds to out intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 
-These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level commands, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img width="850px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
+<img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/38e9d3fd-af93-4f89-b17b-e56a3b13244a"/>
 </p>
 
-In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
-
-Let's consider **Syntax → Expr** commands:
+In the image above:
 
 - `syntax ~ : command` - low-level command we just discussed (I write `command` here for succinctness, but it can be `term`, `:tactic`, etc.).  
 
+- `@[macro] def ~ : Macro` - low-level command we just discussed.  
+
 - `@[command_elab ~] def ~ : CommandElab` - low-level command we just discussed (I write `CommandElab` here for succinctness, but it can be `Tactic`, `TermElab`, etc.).  
 
-- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
-
-- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
-
-Let's consider **Syntax → Expr** commands:
-
-- `syntax ~ : command` - low-level command we just discussed.  
-
-- `@[macro] def ~ : Macro` - low-level command we just discussed.  
 
 - `macro_rules` - sugar for `@[macro] def ~ : Macro`.  
 
+- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
+
 - `macro` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`.  
 
-- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro` - they differ from `macro` in that you can only define rather simple syntax using them.
+- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`. These commands differ from `macro` in that you can only define rather simple syntax with them.
+
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
 
 ## Order of execution: syntax, macro, elab
 
@@ -159,7 +154,7 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/lean/main/overview.lean
+++ b/lean/main/overview.lean
@@ -78,7 +78,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
+<img width="850px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
 </p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
@@ -135,15 +135,15 @@ red -- finally, blue!
 
 The process is as follows:
 
-> match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
-> apply `@[macro xxx]` ➤
->
-> match appropriate syntax rule (happens to have `name := yyy`) ➤  
-> apply `@[macro yyy]` ➤
->
-> match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
-> can't find any macros with name `zzz` to apply,  
-> so apply `@[command_elab zzz]`.  🎉.
+- match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
+    apply `@[macro xxx]` ➤
+
+- match appropriate `syntax` rule (happens to have `name := yyy`) ➤  
+    apply `@[macro yyy]` ➤
+
+- match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
+    can't find any macros with name `zzz` to apply,  
+    so apply `@[command_elab zzz]`.  🎉.
 
 The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from these first principles.
 
@@ -159,7 +159,7 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" (Zulip thread)[https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290]. So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/md/main/intro.md
+++ b/md/main/intro.md
@@ -5,7 +5,8 @@
 This book aims to build up enough knowledge about metaprogramming in Lean 4 so
 you can be comfortable enough to:
 
-* Start building your own meta helpers
+* Start building your own meta helpers (defining new Lean notation such as `∑`,
+building new Lean commands such as `#check`, writing your own tactics such as `use`, etc.)
 * Read and discuss metaprogramming API's like the ones in Lean 4 core and
 Mathlib4
 
@@ -19,7 +20,7 @@ is a highly recommended source on that subject.
 
 ## Book structure
 
-The book is organized in a way to build up enough content for the chapters that
+The book is organized in a way to build up enough context for the chapters that
 cover DSLs and tactics. Backtracking the pre-requisites for each chapter, the
 dependency structure is as follows:
 
@@ -30,8 +31,8 @@ dependency structure is as follows:
 * "`MetaM`" builds on top of "Expressions"
 
 After the chapter on tactics, you find a cheat-sheet containing a wrap-up of key
-concepts and functions. And after that, There are some chapters with extra
-content, showing other applications of metaprogramming in Lean 4.
+concepts and functions. And after that, there are some chapters with extra
+content, showing other applications of metaprogramming in Lean 4. Most chapters contain exercises in the end of the chapter - and in the end of the book you will have full solutions to those exercises.  
 
 The rest of this chapter is a gentle introduction for what metaprogramming is,
 offering some small examples to serve as appetizers for what the book shall
@@ -46,8 +47,8 @@ When we write code in most programming languages such as Python, C, Java or
 Scala, we usually have to stick to a pre-defined syntax otherwise the compiler
 or the interpreter won't be able to figure out what we're trying to say. In
 Lean, that would be defining an inductive type, implementing a function, proving
-a theorem etc. The compiler, then, has to parse the code, build an abstract
-syntax tree and elaborate its syntax nodes into terms that can be processed by
+a theorem, etc. The compiler, then, has to parse the code, build an AST (abstract
+syntax tree) and elaborate its syntax nodes into terms that can be processed by
 the language kernel. We say that such activities performed by the compiler are
 done in the __meta-level__, which will be studied throughout the book. And we
 also say that the common usage of the language syntax is done in the
@@ -55,32 +56,38 @@ __object-level__.
 
 In most systems, the meta-level activities are done in a different language to
 the one that we use to write code. In Isabelle, the meta-level language is ML
-and Scala. In Coq, it's OCaml. In Agda it's Haskell. In Lean 4, the meta code is
+and Scala. In Coq, it's OCaml. In Agda, it's Haskell. In Lean 4, the meta code is
 mostly written in Lean itself, with a few components written in C++.
 
 One cool thing about Lean, though, is that it allows us to define custom syntax
 nodes and to implement our own meta-level routines to elaborate those in the
 very same development environment that we use to perform object-level
 activities. So for example, one can write their own notation to instantiate a
-term of a certain type and use it right away, on the same file! This concept is
+term of a certain type and use it right away, in the same file! This concept is
 generally called
 [__reflection__](https://en.wikipedia.org/wiki/Reflective_programming). We can
 say that, in Lean, the meta-level is _reflected_ to the object-level.
 
-Since the objects defined in the meta-level are not the ones we're most
-interested in proving theorems about, it can sometimes be overly tedious to
-prove that they are type correct. For example, we don't care about proving that
-a recursive function to traverse an expression is well founded. Thus, we can
-use the `partial` keyword if we're convinced that our function terminates. In
-the worst case scenario, our function gets stuck in a loop but the kernel is
-not reached/affected.
+If you have done some metaprogramming in languages such as Ruby, Python or Javascript,
+it probably took a form of making use of predefined metaprogramming methods in order to define
+something on the fly. For example, in Ruby you can use `Class.new` and `define_method`
+to define a new class and its new method (with new code inside!) on the fly, as your program is executing.
 
-Let's see some example use cases of metaprogramming in Lean.
+We don't usually need to define new commands or tactics "on the fly" in Lean, but spiritually
+similar feats are possible with Lean metaprogramming, and are equally straightforward, e.g. you can define
+a new Lean command using a simple one-liner `elab "#help" : command => do ...normal Lean code...`.
+
+In Lean, however, we will frequently want to directly manipulate
+Lean's CST (Concrete Syntax Tree, Lean's `Syntax` type) and
+Lean's AST (Abstract Syntax Tree, Lean's `Expr` type) instead of using "normal Lean code",
+especially when we're writing tactics. So Lean metaprogramming is more challenging to master -
+a large chunk of this book is contributed to studying these types and how we can manipulate them.
 
 ## Metaprogramming examples
 
-The following examples are meant for mere illustration. Don't worry if you don't
-understand the details for now.
+Next, we introduce a number of examples of Lean metaprogramming, so that you start getting a taste for
+what metaprogramming in Lean is, and what it will enable you to achieve. These examples are meant as
+mere illustration - do not worry if you don't understand the details for now.
 
 ### Introducing notation (defining new syntax)
 
@@ -249,24 +256,3 @@ the proof of `t`, which we can introduce to the context using `intro1P` and
 To require the proof of the new hypothesis as a goal, we call `replaceMainGoal`
 passing a list with `p.mvarId!` in the head. And then we can use the
 `rotate_left` tactic to move the recently added top goal to the bottom.
-
-## Printing Messages
-
-In the `#assertType` example, we used `logInfo` to make our command print
-something. If, instead, we just want to perform a quick debug, we can use
-`dbg_trace`.
-
-They behave a bit differently though, as we can see below:
-
-```lean
-elab "traces" : tactic => do
-  let array := List.replicate 2 (List.range 3)
-  Lean.logInfo m!"logInfo: {array}"
-  dbg_trace f!"dbg_trace: {array}"
-
-example : True := by -- `example` is underlined in blue, outputting:
-                     -- dbg_trace: [[0, 1, 2], [0, 1, 2]]
-  traces -- now `traces` is underlined in blue, outputting
-         -- logInfo: [[0, 1, 2], [0, 1, 2]]
-  trivial
-```

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -11,7 +11,7 @@ Metaprogramming in Lean is deeply connected to the compilation steps - parsing, 
 > Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
 
 <p align="center">
-<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>
+<img width="700px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/78867009-2624-46a3-a1f4-f488fd25d494"/>
 </p>
 
 First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
@@ -77,7 +77,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+<img src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
 </p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
@@ -150,7 +150,7 @@ The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from th
 Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
 
 <p align="center">
-<img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+<img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/b403e650-dab4-4843-be8c-8fb812695a3a"/>
 </p>
 
 Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -77,7 +77,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
+<img width="850px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
 </p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
@@ -133,15 +133,15 @@ red -- finally, blue!
 
 The process is as follows:
 
-> match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
-> apply `@[macro xxx]` ➤
->
-> match appropriate syntax rule (happens to have `name := yyy`) ➤  
-> apply `@[macro yyy]` ➤
->
-> match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
-> can't find any macros with name `zzz` to apply,  
-> so apply `@[command_elab zzz]`.  🎉.
+- match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
+    apply `@[macro xxx]` ➤
+
+- match appropriate `syntax` rule (happens to have `name := yyy`) ➤  
+    apply `@[macro yyy]` ➤
+
+- match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
+    can't find any macros with name `zzz` to apply,  
+    so apply `@[command_elab zzz]`.  🎉.
 
 The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from these first principles.
 
@@ -157,7 +157,7 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" (Zulip thread)[https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290]. So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -74,35 +74,30 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
     **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
     This corresponds to out intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 
-These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level commands, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
-<img width="850px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/7ad8930a-a486-41c9-b6af-2e8455b804a4"/>
+<img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/38e9d3fd-af93-4f89-b17b-e56a3b13244a"/>
 </p>
 
-In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
-
-Let's consider **Syntax → Expr** commands:
+In the image above:
 
 - `syntax ~ : command` - low-level command we just discussed (I write `command` here for succinctness, but it can be `term`, `:tactic`, etc.).  
 
+- `@[macro] def ~ : Macro` - low-level command we just discussed.  
+
 - `@[command_elab ~] def ~ : CommandElab` - low-level command we just discussed (I write `CommandElab` here for succinctness, but it can be `Tactic`, `TermElab`, etc.).  
 
-- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
-
-- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
-
-Let's consider **Syntax → Expr** commands:
-
-- `syntax ~ : command` - low-level command we just discussed.  
-
-- `@[macro] def ~ : Macro` - low-level command we just discussed.  
 
 - `macro_rules` - sugar for `@[macro] def ~ : Macro`.  
 
+- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
+
 - `macro` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`.  
 
-- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro` - they differ from `macro` in that you can only define rather simple syntax using them.
+- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`. These commands differ from `macro` in that you can only define rather simple syntax with them.
+
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
 
 ## Order of execution: syntax, macro, elab
 
@@ -157,7 +152,7 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -32,14 +32,14 @@ So, the compiler sees a string of Lean code, say `"let a := 2"`, and the followi
 
 3. **apply a single elab** (`Syntax` ➤ `Expr`)  
 
-    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** that's matched to the appropriate **syntax rule** by the `:name` argument (**macros**, **syntax rules** and **elabs** all have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
+    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** that's matched to the appropriate **syntax rule** by the `:name` argument (**syntax rules**, **macros** and **elabs** all have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
     This completes the elaboration step.
 
 Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
 
 ## Elaboration and delaboration
 
-Elaboration is a loaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
+Elaboration is a overloaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
 
 
 > When you enter an expression like `λ x y z, f (x + y) z` for Lean to process, you are leaving information implicit. For example, the types of `x`, `y`, and `z` have to be inferred from the context, the notation `+` may be overloaded, and there may be implicit arguments to `f` that need to be filled in as well.
@@ -68,7 +68,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 
 In the image above, you see `notation`, `prefix`, `infix`, and `postfix` - all of these are combinations of `syntax` and `@[macro xxx] def ourMacro`, just like `macro`. These commands differ from `macro` in that you can only define syntax of particular form with them.
 
-All of these commands are used in Lean and Mathlib source code extensively, so it's well worth memorizing them. Most of them are syntax sugars, however, and you can understand their behaviour by studying the behaviour of these 3 low-level commands: `syntax` (a **syntax rule**), `@[macro xxx] def ourMacro` (a **macro**), and `@[command_elab xxx] def ourElab` (an **elab**).
+All of these commands are used in Lean and Mathlib source code extensively, so it's well worth memorizing them. Most of them are syntax sugars, however, and you can understand their behaviour by studying the behaviour of the following 3 low-level commands: `syntax` (a **syntax rule**), `@[macro xxx] def ourMacro` (a **macro**), and `@[command_elab xxx] def ourElab` (an **elab**).
 
 To give a more concrete example, imagine we're implementing a `#help` command, that can also be written as `#h`. Then we can write our **syntax rule**, **macro**, and **elab** as follows:
 
@@ -76,18 +76,18 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 <img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 non-syntax-sugary commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
 
 If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
 
 If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 
 If we were defining something other than a command, instead of `: command` we could write `: term`, or `: tactic`, or any other syntax category.  
-The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`.  
+The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`:  
 
-`TermElab` stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
-`CommandElab` stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
-`Tactic` stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
+- `TermElab` stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
+- `CommandElab` stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+- `Tactic` stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
 
 This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -78,7 +78,7 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 
 This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 non-syntax-sugary commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
 
-If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see "*"Displays proof in a Fitch table""* logged in VSCode's infoview.
+If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
 
 If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -10,8 +10,9 @@ Metaprogramming in Lean is deeply connected to the compilation steps - parsing, 
 >
 > Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
 
-
-<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>  
+<p align="center">
+<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>
+</p>
 
 First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
 So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
@@ -75,7 +76,9 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 
 These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
+<p align="center">
 <img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+</p>
 
 In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
 
@@ -87,7 +90,7 @@ Let's consider **Syntax → Expr** commands:
 
 - `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
 
-- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab` 
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
 
 Let's consider **Syntax → Expr** commands:
 
@@ -146,7 +149,9 @@ The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from th
 
 Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
 
+<p align="center">
 <img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+</p>
 
 Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -76,11 +76,12 @@ To give a more concrete example, imagine we're implementing a `#help` command, t
 <img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 low-level commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command - *"Displays proof in a Fitch table"*.
 
-If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see *"Displays proof in a Fitch table"* logged in VSCode's infoview.
+If we write `#h "#explode"`, Lean will travel the `syntax (name := shortcut_h)` ➤ `@[macro shortcut_h] def helpMacro` ➤ `syntax (name := default_h)` ➤ `@[command_elab default_h] def helpElab` route.  
+If we write `#help "#explode"`, Lean will travel the `syntax (name := default_h)` ➤ `@[command_elab default_h] def helpElab` route.
 
-If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
+Note how the matching between **syntax rules**, **macros**, and **elabs** is done via the `name` attribute. If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
 
 If we were defining something other than a command, instead of `: command` we could write `: term`, or `: tactic`, or any other syntax category.  
 The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`:  

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -64,24 +64,41 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 
 - **syntax rule: `syntax (name := xxx) ... : command`**
 
-    For example, `syntax (name := xxx) "#help" "option" (ident)? : command` is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.   
+    For example,
+    ```
+    syntax (name := xxx) "#help" "option" (ident)? : command
+    ```
+    This is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.  
     Other widespread syntax categories are `tactic` and `term`, all of these are used in different physical places in your code.
 
 - **macro: `@[macro xxx] def ourMacro : Macro := ...`**
 
-    For example, ``@[macro xxx] def ourMacro : Macro := λ stx => match stx with | _ => `(tactic| pick_goal 2)``. Whenever your Lean code matches the syntax rule with the name `xxx`, this macro will be applied.  
-    If the syntax rule was `syntax (name := xxx) "swap" : tactic`, this macro will syntactically turn `swap` into `pick_goal 2` - and the subsequent elaboration step will be handled by the `pick_goal 2` syntax rule.
+    For example,
+    ```
+    @[macro xxx]
+    def ourMacro : Macro := λ stx =>
+      match stx with | _ => `(tactic| pick_goal 2)
+    ```
+    Whenever your Lean code matches the syntax rule with the name `"xxx"`, this macro will be applied.  
+    If the syntax rule was `syntax (name := xxx) "swap" : tactic`, this macro will syntactically turn `"swap"` into `"pick_goal 2"` - and the subsequent elaboration step will be handled by the syntax rule that matches `"pick_goal 2"`.
 
 - **elab: `@[command_elab xxx] def ourElab : CommandElab := ...`**
 
-    For example, ``@[term_elab our_help] def ourElab : TermElab := λ stx tp => (Expr.app (Expr.const `Nat.add []))``.  
-    Our `elab` function can be of different types - the **CommandElab** and **TermElab** that you saw already, and **Tactic**.  
-    **TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elaboration function is expected to return the **Expr** object.  
+    For example,
+    ```
+    @[command_elab xxx]
+    def ourElab : CommandElab := λ stx tp =>
+      Lean.logInfo "Helping"
+    ```  
+    Our elab function can be of different types - the **CommandElab** you have just seen, **TermElab** and **Tactic**.  
+
+    **TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
     **CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
     **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
-    This corresponds to out intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 
-These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level commands, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+    This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
+
+These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level commands, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars for these commands, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
 
 <p align="center">
 <img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/38e9d3fd-af93-4f89-b17b-e56a3b13244a"/>
@@ -108,7 +125,7 @@ In the image above:
 
 ## Order of execution: syntax, macro, elab
 
-We have hinted at the flow of execution of these three essential functions here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `(syntax; macro)+ elab`.
+We have hinted at the flow of execution of these three essential functions here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `syntax (macro; syntax)* elab`.
 
 Consider the following example.
 
@@ -149,7 +166,7 @@ The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from th
 
 ## Manual conversions between `Syntax`/`Expr`/executable-code
 
-Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
+Lean will execute the aforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
 
 <p align="center">
 <img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/b403e650-dab4-4843-be8c-8fb812695a3a"/>

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -210,5 +210,6 @@ interested in proving theorems about, it can sometimes be overly tedious to
 prove that they are type correct. For example, we don't care about proving that
 a recursive function to traverse an expression is well founded. Thus, we can
 use the `partial` keyword if we're convinced that our function terminates. In
-the worst case scenario, our function gets stuck in a loop but the kernel is
-not reached/affected.
+the worst case scenario, our function gets stuck in a loop, Lean server crashes
+in VSCode, but the soundness of the underlying type theory implemented in kernel
+isn't affected.

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -22,17 +22,17 @@ First we will have Lean code as a string. Then `Syntax` object. Then `Expr` obje
 
 So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
 
-1. **apply a relevant `syntax` rule** (`"let a := 2"` ➤ `Syntax`)  
+1. **apply a relevant syntax rule** (`"let a := 2"` ➤ `Syntax`)  
 
-    During the parsing step, Lean applies all declared `syntax` rules to turn a string of Lean code into the `Syntax` object. `syntax` rules are basically glorified regular expressions - when you write a Lean string that matches a certain `syntax` rule's regex, that rule will be used to handle subsequent steps.
+    During the parsing step, Lean applies all declared **syntax** rules to turn a string of Lean code into the `Syntax` object. **syntax** rules are basically glorified regular expressions - when you write a Lean string that matches a certain **syntax** rule's regex, that rule will be used to handle subsequent steps.
 
-2. **apply all `macro`s in a loop** (`Syntax` ➤ `Syntax`)  
+2. **apply all macros in a loop** (`Syntax` ➤ `Syntax`)  
 
-    During the elaboration step, each `macro` simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more `macro`s to apply.
+    During the elaboration step, each **macro** simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more **macro**s to apply.
 
-3. **apply a single `elab`** (`Syntax` ➤ `Expr`)  
+3. **apply a single elab** (`Syntax` ➤ `Expr`)  
 
-    Finally, it's time to infuse your syntax with meaning - Lean finds an `elab` rule that's matched to the appropriate `syntax` rule by the `:name` argument (both the `syntax` rule and `elab` rule have this argument, and they must match). The newfound `elab` returns a particular `Expr` object.
+    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** rule that's matched to the appropriate **syntax** rule by the `:name` argument (both the **syntax** rule and **elab** rule have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
     This completes the elaboration step.
 
 Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
@@ -60,9 +60,15 @@ Throughout this book you will see references to the elaborator; and in the "Extr
 
 ## 3 essential functions and their syntax sugars
 
-Now, when you're reading Lean source code, you will see 11(+?) commands specifying the **parsing**/**elaboration**/**evaluation** process.  Most of them are syntax sugar, and you only need **3 commands** to do metaprogramming in Lean:
+Now, when you're reading Lean source code, you will see 11(+?) commands specifying the **parsing**/**elaboration**/**evaluation** process:
 
-- **syntax rule: `syntax (name := xxx) ... : command`**
+<p align="center">
+<img width="500px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/9b83f06c-49c4-4d93-9d42-72e0499ae6c8"/>
+</p>
+
+As you can see from the image above, most of them are syntax sugars, and you only need **3 commands** to do metaprogramming in Lean:
+
+- **syntax rule: `syntax`**
 
     For example,
     ```
@@ -71,7 +77,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
     This is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.  
     Other widespread syntax categories are `tactic` and `term`, all of these are used in different physical places in your code.
 
-- **macro: `@[macro xxx] def ourMacro : Macro := ...`**
+- **macro: `@[macro xxx] def ourMacro`**
 
     For example,
     ```
@@ -82,7 +88,7 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
     Whenever your Lean code matches the syntax rule with the name `"xxx"`, this macro will be applied.  
     If the syntax rule was `syntax (name := xxx) "swap" : tactic`, this macro will syntactically turn `"swap"` into `"pick_goal 2"` - and the subsequent elaboration step will be handled by the syntax rule that matches `"pick_goal 2"`.
 
-- **elab: `@[command_elab xxx] def ourElab : CommandElab := ...`**
+- **elab: `@[command_elab xxx] def ourElab`**
 
     For example,
     ```
@@ -90,38 +96,24 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
     def ourElab : CommandElab := λ stx tp =>
       Lean.logInfo "Helping"
     ```  
-    Our elab function can be of different types - the **CommandElab** you have just seen, **TermElab** and **Tactic**.  
+    Finally, the elaboration command provides our syntax with meaning. If Lean matched some syntax rule, and didn't find any further macros to apply, it will find the elab with the matching name (`"xxx"`), and execute it.
 
-    **TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
-    **CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
-    **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
 
-    This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
+In the image above, you saw `notation`, `prefix`, `infix`, and `postfix` - all of these are combinations of `syntax` and `@[macro xxx] def ourMacro`, just like `macro`. These commands differ from `macro` in that you can only define syntax of particular form with them.
 
-These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level commands, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars for these commands, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+To give a more concrete example, imagine we're implementing a `#help` command, that can also be written as `#h`. Then we can write our **syntax**, **macro**, and **elab** as follows:
 
 <p align="center">
-<img width="650px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/38e9d3fd-af93-4f89-b17b-e56a3b13244a"/>
+<img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-In the image above:
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. If we were defining something other than a command, instead of `: command` we could write `: term` or `: tactic`. The elab function can also be of different types - the `CommandElab` we used to implement the `#help` command - but also `TermElab` and `Tactic`.  
 
-- `syntax ~ : command` - low-level command we just discussed (I write `command` here for succinctness, but it can be `term`, `:tactic`, etc.).  
+**TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
+**CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+**Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
 
-- `@[macro] def ~ : Macro` - low-level command we just discussed.  
-
-- `@[command_elab ~] def ~ : CommandElab` - low-level command we just discussed (I write `CommandElab` here for succinctness, but it can be `Tactic`, `TermElab`, etc.).  
-
-
-- `macro_rules` - sugar for `@[macro] def ~ : Macro`.  
-
-- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
-
-- `macro` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`.  
-
-- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`. These commands differ from `macro` in that you can only define rather simple syntax with them.
-
-- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab`.  
+This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 
 ## Order of execution: syntax, macro, elab
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -1,0 +1,190 @@
+# Overview
+
+In this chapter, we will go through the fundamental concepts behind Lean metaprogramming, and how they interact. In the next chapters, you will learn the particulars. As you read on, you might want to return to this chapter occasionally to remind yourself of how it all fits together.
+
+## Connection to compilers
+
+Metaprogramming in Lean is deeply connected to the compilation steps - parsing, syntactic analysis, transformation, and code generation.
+
+> Lean 4 is a reimplementation of the Lean theorem prover in Lean itself. The new compiler produces C code, and users can now implement efficient proof automation in Lean, compile it into efficient C code, and load it as a plugin. In Lean 4, users can access all internal data structures used to implement Lean by merely importing the Lean package.
+>
+> Leonardo de Moura, Sebastian Ullrich ([The Lean 4 Theorem Prover and Programming Language](https://pp.ipd.kit.edu/uploads/publikationen/demoura21lean4.pdf))
+
+
+<img width="700px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/325233868b9e52982d5835dac90abfd1cc5a06be3eb0e41c.png/w_1592"/>  
+
+First we will have Lean code as a string. Then `Syntax` object. Then `Expr` object. Then we can execute it.  
+So, the compiler sees a string of Lean code, say `"let a := 2"`, and the following process unfolds:
+
+1. **apply a relevant `syntax` rule** (`"let a := 2"` ➤ `Syntax`)  
+
+    During the parsing step, Lean applies all declared `syntax` rules to turn a string of Lean code into the `Syntax` object. `syntax` rules are basically glorified regular expressions - when you write a Lean string that matches a certain `syntax` rule's regex, that rule will be used to handle subsequent steps.
+
+2. **apply all `macro`s in a loop** (`Syntax` ➤ `Syntax`)  
+
+    During the elaboration step, each `macro` simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more `macro`s to apply.
+
+3. **apply a single `elab`** (`Syntax` ➤ `Expr`)  
+
+    Finally, it's time to infuse your syntax with meaning - Lean finds an `elab` rule that's matched to the appropriate `syntax` rule by the name argument (both the `syntax` rule and `elab` rule have this argument, and they must match). The newfound `elab` returns a particular `Expr` object.
+    This completes the elaboration step.
+
+Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
+
+## Elaboration and delaboration
+
+Elaboration is a loaded term in Lean, for example you can meet the following usage of the word "elaboration", which defines elaboration as *"taking a partially-specified expression and inferring what is left implicit"*:
+
+
+> When you enter an expression like `λ x y z, f (x + y) z` for Lean to process, you are leaving information implicit. For example, the types of `x`, `y`, and `z` have to be inferred from the context, the notation `+` may be overloaded, and there may be implicit arguments to `f` that need to be filled in as well.
+>
+> The process of *taking a partially-specified expression and inferring what is left implicit* is known as **elaboration**. Lean's **elaboration** algorithm is powerful, but at the same time, subtle and complex. Working in a system of dependent type theory requires knowing what sorts of information the **elaborator** can reliably infer, as well as knowing how to respond to error messages that are raised when the elaborator fails. To that end, it is helpful to have a general idea of how Lean's **elaborator** works.
+>
+> When Lean is parsing an expression, it first enters a preprocessing phase. First, Lean inserts "holes" for implicit arguments. If term t has type `Π {x : A}, P x`, then t is replaced by `@t _` everywhere. Then, the holes — either the ones inserted in the previous step or the ones explicitly written by the user — in a term are instantiated by metavariables `?M1`, `?M2`, `?M3`, .... Each overloaded notation is associated with a list of choices, that is, the possible interpretations. Similarly, Lean tries to detect the points where a coercion may need to be inserted in an application `s t`, to make the inferred type of t match the argument type of `s`. These become choice points too. If one possible outcome of the elaboration procedure is that no coercion is needed, then one of the choices on the list is the identity.  
+>
+> ([Theorem Proving in Lean 2](http://leanprover.github.io/tutorial/08_Building_Theories_and_Proofs.html))
+
+These definitions are not mutually exclusive - elaboration is the transformation of `Syntax` into `Expr`s - it's just so that for this transformation to happen we need a lot of trickery - we need to infer implicit arguments, instantiate metavariables, perform unification, resolve identifiers, etc. etc. - and these actions can be referred to as "elaboration" on their own; similarly to how "checking if you turned off the lights in your apartment" (metavariable instantiation) can be referred to as "going to school" (elaboration).
+
+There also exists a process opposite to elaboration in Lean - it's called, appropriately enough, delaboration. During delaboration, `Expr` is turned into the `Syntax` object; and then the formatter turns it into a `Format` object, which can be displayed in Lean's infoview. Every time you log something to the screen, or see some output upon hovering over `#check`, it's the work of delaborator.
+
+Throughout this book you will see references to the elaborator; and in the "Pretty Printing" extra chapter you can read on delaborators.
+
+## 3 essential functions and their syntax sugars
+
+Now, when you're reading Lean source code, you will see 11(+?) commands specifying the **parsing**/**elaboration**/**evaluation** process.  Most of them are syntax sugar, and you only need **3 commands** to do metaprogramming in Lean:
+
+- **syntax rule: `syntax (name := xxx) ... : command`**
+
+    For example, `syntax (name := xxx) "#help" "option" (ident)? : command` is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.   
+    Other widespread syntax categories are `tactic` and `term`, all of these are used in different physical places in your code.
+
+- **macro: `@[macro xxx] def ourMacro : Macro := ...`**
+
+    For example, ``@[macro xxx] def ourMacro : Macro := λ stx => match stx with | _ => `(tactic| pick_goal 2)``. Whenever your Lean code matches the syntax rule with the name `xxx`, this macro will be applied.  
+    If the syntax rule was syntax `(name := xxx) "swap" : tactic`, this macro will syntactically turn `swap` into `pick_goal 2` - and the subsequent elaboration step will be handled by the `pick_goal 2` syntax rule.
+
+- **elab: `@[command_elab xxx] def ourElab : CommandElab := ...`**
+
+    For example, ``@[term_elab our_help] def ourElab : TermElab := λ stx tp => (Expr.app (Expr.const `Nat.add []))``.  
+    Our `elab` function can be of different types - the **CommandElab** and **TermElab** that you saw already, and **Tactic**.  
+    **TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elaboration function is expected to return the **Expr** object.  
+    **CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+    **Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
+    This corresponds to out intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
+
+These `syntax (name := xxx) ... : command`, `@[macro xxx] def ourMacro : Macro := ...` and `@[command_elab xxx] def ourElab : CommandElab := ...` are the 3 essential, low-level functions, and you can get away with them only. Lean standard library and Mathlib use many syntax sugars, however, so memorizing them is well worth the effort. I'm summing them up in the next diagram.
+
+<img src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/118a91998ce7632aac13efad0cab55f476bf2a2b0c3706b1.png/w_2118"/>
+
+In the image above, each row shows the commands that you have to use together (if you use one of them). For example, you cannot use `elab_rules` if you do not have the appropriate `syntax ~ : command` defined yet.
+
+Let's consider **Syntax → Expr** commands:
+
+- `syntax ~ : command` - low-level command we just discussed (I write `command` here for succinctness, but it can be `term`, `:tactic`, etc.).  
+
+- `@[command_elab ~] def ~ : CommandElab` - low-level command we just discussed (I write `CommandElab` here for succinctness, but it can be `Tactic`, `TermElab`, etc.).  
+
+- `elab_rules` - sugar for `@[command_elab ~] def ~ : CommandElab`.  
+
+- `elab` - combination of `syntax ~ : command` and `@[command_elab ~] def ~ : CommandElab` 
+
+Let's consider **Syntax → Expr** commands:
+
+- `syntax ~ : command` - low-level command we just discussed.  
+
+- `@[macro] def ~ : Macro` - low-level command we just discussed.  
+
+- `macro_rules` - sugar for `@[macro] def ~ : Macro`.  
+
+- `macro` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro`.  
+
+- `notation`, `prefix`, `infix`, `postfix` - combination of `syntax ~ : command` and `@[macro] def ~ : Macro` - they differ from `macro` in that you can only define rather simple syntax using them.
+
+## Order of execution: syntax, macro, elab
+
+We have hinted at the flow of execution of these three essential functions here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `(syntax; macro)+ elab`.
+
+Consider the following example.
+
+```lean
+import Lean
+
+syntax (name := xxx) "red" : command
+syntax (name := yyy) "green" : command
+syntax (name := zzz) "blue" : command
+
+@[macro xxx] def redMacro : Lean.Macro := λ stx =>
+  match stx with
+  | _ => `(green)
+
+@[macro yyy] def greenMacro : Lean.Macro := λ stx =>
+  match stx with
+  | _ => `(blue)
+
+@[command_elab zzz] def blueElab : Lean.Elab.Command.CommandElab := λ stx =>
+  Lean.logInfo "finally, blue!"
+
+red -- finally, blue!
+```
+
+The process is as follows:
+
+> match appropriate `syntax` rule (happens to have `name := xxx`) ➤  
+> apply `@[macro xxx]` ➤
+>
+> match appropriate syntax rule (happens to have `name := yyy`) ➤  
+> apply `@[macro yyy]` ➤
+>
+> match appropriate `syntax` rule (happens to have `name := zzz`) ➤  
+> can't find any macros with name `zzz` to apply,  
+> so apply `@[command_elab zzz]`.  🎉.
+
+The behaviour of syntax sugars (`elab`, `macro`, etc.) can be understood from these first principles.
+
+## Manual conversions between `Syntax`/`Expr`/executable-code
+
+Lean will execute the afforementioned **parsing**/**elaboration**/**evaluation** steps for you automatically if you use `syntax`, `macro` and `elab` commands, however, when you're writing your tactics, you will also frequently need to perform these transitions manually. You can use the following functions for that:
+
+<img width="650px" src="https://71022.cdn.cke-cs.com/RructTCFEHceQFc13ldy/images/11ed9f7c1e0b70a73922a06b24d94033b85028030fdd4670.png/w_1474"/>
+
+Note how all functions that let us turn `Syntax` into `Expr` start with "elab", short for "elaboration"; and all functions that let us turn `Expr` (or `Syntax`) into `actual code` start with "eval", short for "evaluation".
+
+## Assigning meaning: macro VS elaboration?
+
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" (Zulip thread)[https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290]. So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+
+## Additional comments
+
+Finally - some notes that should clarify a few things as you read the coming chapters.
+
+### Printing Messages
+
+In the `#assertType` example, we used `logInfo` to make our command print
+something. If, instead, we just want to perform a quick debug, we can use
+`dbg_trace`.
+
+They behave a bit differently though, as we can see below:
+
+```lean
+elab "traces" : tactic => do
+  let array := List.replicate 2 (List.range 3)
+  Lean.logInfo m!"logInfo: {array}"
+  dbg_trace f!"dbg_trace: {array}"
+
+example : True := by -- `example` is underlined in blue, outputting:
+                     -- dbg_trace: [[0, 1, 2], [0, 1, 2]]
+  traces -- now `traces` is underlined in blue, outputting
+         -- logInfo: [[0, 1, 2], [0, 1, 2]]
+  trivial
+```
+
+### Type correctness
+
+Since the objects defined in the meta-level are not the ones we're most
+interested in proving theorems about, it can sometimes be overly tedious to
+prove that they are type correct. For example, we don't care about proving that
+a recursive function to traverse an expression is well founded. Thus, we can
+use the `partial` keyword if we're convinced that our function terminates. In
+the worst case scenario, our function gets stuck in a loop but the kernel is
+not reached/affected.

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -145,7 +145,9 @@ Note how all functions that let us turn `Syntax` into `Expr` start with "elab", 
 
 ## Assigning meaning: macro VS elaboration?
 
-In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)). So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
+In principle, you can do with a `macro` (almost?) anything you can do with the `elab` function. Just write what you would have in the body of your `elab` as a syntax within `macro`. However, the rule of thumb here is to only use `macro`s when the conversion is simple and truly feels elementary to the point of aliasing. As Henrik Böving puts it: "as soon as types or control flow is involved a macro is probably not reasonable anymore" ([Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/The.20line.20between.20term.20elaboration.20and.20macro/near/280951290)).  
+
+So - use `macro`s for creating syntax sugars, notations, and shortcuts, and prefer `elab`s for writing out code with some programming logic, even if it's potentially implementable in a `macro`.
 
 ## Additional comments
 

--- a/md/main/overview.md
+++ b/md/main/overview.md
@@ -24,15 +24,15 @@ So, the compiler sees a string of Lean code, say `"let a := 2"`, and the followi
 
 1. **apply a relevant syntax rule** (`"let a := 2"` ➤ `Syntax`)  
 
-    During the parsing step, Lean applies all declared **syntax** rules to turn a string of Lean code into the `Syntax` object. **syntax** rules are basically glorified regular expressions - when you write a Lean string that matches a certain **syntax** rule's regex, that rule will be used to handle subsequent steps.
+    During the parsing step, Lean tries to match a string of Lean code to one of the declared **syntax rules** in order to turn that string into the `Syntax` object. **Syntax rules** are basically glorified regular expressions - when you write a Lean string that matches a certain **syntax rule**'s regex, that rule will be used to handle subsequent steps.
 
 2. **apply all macros in a loop** (`Syntax` ➤ `Syntax`)  
 
-    During the elaboration step, each **macro** simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more **macro**s to apply.
+    During the elaboration step, each **macro** simply turns the existing `Syntax` object into some new `Syntax` object. Then, the new `Syntax` is processed in a similar way (steps 1 and 2), until there are no more **macros** to apply.
 
 3. **apply a single elab** (`Syntax` ➤ `Expr`)  
 
-    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** rule that's matched to the appropriate **syntax** rule by the `:name` argument (both the **syntax** rule and **elab** rule have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
+    Finally, it's time to infuse your syntax with meaning - Lean finds an **elab** that's matched to the appropriate **syntax rule** by the `:name` argument (**macros**, **syntax rules** and **elabs** all have this argument, and they must match). The newfound **elab** returns a particular `Expr` object.
     This completes the elaboration step.
 
 Expression (`Expr`) is then converted to the executable code during the evaluation step - we don't have to specify that in any way, Lean compiler will handle that for us.
@@ -58,7 +58,7 @@ There also exists a process opposite to elaboration in Lean - it's called, appro
 
 Throughout this book you will see references to the elaborator; and in the "Extra: Pretty Printing" chapter you can read on delaborators.
 
-## 3 essential functions and their syntax sugars
+## 3 essential commands and their syntax sugars
 
 Now, when you're reading Lean source code, you will see 11(+?) commands specifying the **parsing**/**elaboration**/**evaluation** process:
 
@@ -66,77 +66,54 @@ Now, when you're reading Lean source code, you will see 11(+?) commands specifyi
 <img width="500px" src="https://github.com/arthurpaulino/lean4-metaprogramming-book/assets/7578559/9b83f06c-49c4-4d93-9d42-72e0499ae6c8"/>
 </p>
 
-As you can see from the image above, most of them are syntax sugars, and you only need **3 commands** to do metaprogramming in Lean:
+In the image above, you see `notation`, `prefix`, `infix`, and `postfix` - all of these are combinations of `syntax` and `@[macro xxx] def ourMacro`, just like `macro`. These commands differ from `macro` in that you can only define syntax of particular form with them.
 
-- **syntax rule: `syntax`**
+All of these commands are used in Lean and Mathlib source code extensively, so it's well worth memorizing them. Most of them are syntax sugars, however, and you can understand their behaviour by studying the behaviour of these 3 low-level commands: `syntax` (a **syntax rule**), `@[macro xxx] def ourMacro` (a **macro**), and `@[command_elab xxx] def ourElab` (an **elab**).
 
-    For example,
-    ```
-    syntax (name := xxx) "#help" "option" (ident)? : command
-    ```
-    This is a syntax rule that will match (remember the regex analogy) all strings in the form of `"#help option hi.hello"` or just `"#help option"`.  
-    Other widespread syntax categories are `tactic` and `term`, all of these are used in different physical places in your code.
-
-- **macro: `@[macro xxx] def ourMacro`**
-
-    For example,
-    ```
-    @[macro xxx]
-    def ourMacro : Macro := λ stx =>
-      match stx with | _ => `(tactic| pick_goal 2)
-    ```
-    Whenever your Lean code matches the syntax rule with the name `"xxx"`, this macro will be applied.  
-    If the syntax rule was `syntax (name := xxx) "swap" : tactic`, this macro will syntactically turn `"swap"` into `"pick_goal 2"` - and the subsequent elaboration step will be handled by the syntax rule that matches `"pick_goal 2"`.
-
-- **elab: `@[command_elab xxx] def ourElab`**
-
-    For example,
-    ```
-    @[command_elab xxx]
-    def ourElab : CommandElab := λ stx tp =>
-      Lean.logInfo "Helping"
-    ```  
-    Finally, the elaboration command provides our syntax with meaning. If Lean matched some syntax rule, and didn't find any further macros to apply, it will find the elab with the matching name (`"xxx"`), and execute it.
-
-
-In the image above, you saw `notation`, `prefix`, `infix`, and `postfix` - all of these are combinations of `syntax` and `@[macro xxx] def ourMacro`, just like `macro`. These commands differ from `macro` in that you can only define syntax of particular form with them.
-
-To give a more concrete example, imagine we're implementing a `#help` command, that can also be written as `#h`. Then we can write our **syntax**, **macro**, and **elab** as follows:
+To give a more concrete example, imagine we're implementing a `#help` command, that can also be written as `#h`. Then we can write our **syntax rule**, **macro**, and **elab** as follows:
 
 <p align="center">
 <img width="900px" src="https://github.com/lakesare/lean4-metaprogramming-book/assets/7578559/adc1284f-3c0a-441d-91b8-7d87b6035688"/>
 </p>
 
-This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. If we were defining something other than a command, instead of `: command` we could write `: term` or `: tactic`. The elab function can also be of different types - the `CommandElab` we used to implement the `#help` command - but also `TermElab` and `Tactic`.  
+This image is not supposed to be read row by row - it's perfectly fine to use `macro_rules` together with `elab`. Suppose, however, that we used the 3 non-syntax-sugary commands to specify our `#help` command (the first row). After we've done this, we can write `#help "#explode"` or `#h "#explode"`, both of which will output a rather parsimonious documentation for the `#explode` command (by the way - `#explode` is a real command from Mathlib 4, as is `#help`) - *"Displays proof in a Fitch table"*.
 
-**TermElab** stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
-**CommandElab** stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
-**Tactic** stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
+If we write `#h "#explode"`, the **syntax rule** with the name `:shortcut_h` will match it (remember the regex analogy). After that, Lean will find the **macro** with the same name, which will turn `#h "#explode"` into `#help "#explode"`. After that, the **syntax rule** with the name `:default_h` will match it. After that, Lean, having found no **macros** with the name `:default_h`, will find an **elab** with the name `:default_h` - and we'll see "*"Displays proof in a Fitch table""* logged in VSCode's infoview.
+
+If we used `macro_rules` or other syntax sugars, Lean would figure out the appropriate `name` attributes on its own.
+
+If we were defining something other than a command, instead of `: command` we could write `: term`, or `: tactic`, or any other syntax category.  
+The elab function can also be of different types - the `CommandElab` we used to implement `#help` - but also `TermElab` and `Tactic`.  
+
+`TermElab` stands for **Syntax → Option Expr → TermElabM Expr**, so the elab function is expected to return the **Expr** object.  
+`CommandElab` stands for **Syntax → CommandElabM Unit**, so it shouldn't return anything.  
+`Tactic` stands for **Syntax → TacticM Unit**, so it shouldn't return anything either.  
 
 This corresponds to our intuitive understanding of terms, commands and tactics in Lean - terms return a particular value upon execution, commands modify the environment or print something out, and tactics modify the proof state.
 
-## Order of execution: syntax, macro, elab
+## Order of execution: syntax rule, macro, elab
 
-We have hinted at the flow of execution of these three essential functions here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `syntax (macro; syntax)* elab`.
+We have hinted at the flow of execution of these three essential commands here and there, however let's lay it out explicitly. The order of execution follows the following pseudocodey template: `syntax (macro; syntax)* elab`.
 
 Consider the following example.
 
 ```lean
 import Lean
+open Lean Elab Command
 
 syntax (name := xxx) "red" : command
 syntax (name := yyy) "green" : command
 syntax (name := zzz) "blue" : command
 
-@[macro xxx] def redMacro : Lean.Macro := λ stx =>
+@[macro xxx] def redMacro : Macro := λ stx =>
   match stx with
   | _ => `(green)
 
-@[macro yyy] def greenMacro : Lean.Macro := λ stx =>
+@[macro yyy] def greenMacro : Macro := λ stx =>
   match stx with
   | _ => `(blue)
 
-@[command_elab zzz] def blueElab : Lean.Elab.Command.CommandElab := λ stx =>
+@[command_elab zzz] def blueElab : CommandElab := λ stx =>
   Lean.logInfo "finally, blue!"
 
 red -- finally, blue!


### PR DESCRIPTION
### In this PR

#### Ch.Introduction

- Added a comment that we now have exercises & solutions for each chapter
- Added a paragraph on how python/ruby metaprogramming differs from what we mean by lean metaprogramming
- Moved **"Printing Messages"** and **"`partial` functions"** paragraphs to the new **Ch.Overview**

#### Ch.Overview

- A new chapter

### Links to the latest versions of updated files

- [**Ch.Introduction**](https://github.com/lakesare/lean4-metaprogramming-book/blob/lakesare_overview/md/main/intro.md)
- [**Ch.Overview**](https://github.com/lakesare/lean4-metaprogramming-book/blob/lakesare_overview/md/main/overview.md)