### PR TITLE
Fix operator precedence in syntax solution

### DIFF
--- a/lean/solutions/05_syntax.lean
+++ b/lean/solutions/05_syntax.lean
@@ -14,7 +14,7 @@ end a
 
 namespace b
   set_option quotPrecheck false
-  scoped infixl:71 " 💀 " => fun lhs rhs => lhs - rhs
+  scoped infixr:71 " 💀 " => fun lhs rhs => lhs - rhs
 end b
 
 namespace c


### PR DESCRIPTION
Since `#eval 8 💀 6 💀 1` is supposed to yield 3 according to the problem statement, we should use `infixr` here.