### PR TITLE
default transparency typo

### DIFF
--- a/lean/main/04_metam.lean
+++ b/lean/main/04_metam.lean
@@ -579,7 +579,7 @@ replaced by `Nat.add`:
 -- Nat.add defaultDef 1
 
 /-!
-With `default` transparency, `Nat.add` is unfolded as well:
+With `default` transparency, `defaultDef` is unfolded as well:
 -/
 
 #eval traceConstWithTransparency .default ``reducibleDef


### PR DESCRIPTION
`defaultDef` is unfolded as well not `Nat.add`